### PR TITLE
Got the drawers working again to reflect changes from invalidated queries

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -38,11 +38,11 @@ function App () {
   const [showDevtools] = useState(webAppConfig.ENABLE_REACT_QUERY_TOOLS !== undefined ? webAppConfig.ENABLE_REACT_QUERY_TOOLS : true);
 
 
-  // Inject this once for the app, for all react-query queries
+  // Inject this once for the app, then it is the default for all ReactQuery queries
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
-        networkMode: 'always', // Send queries to the server even if the cache has the data
+        // networkMode: 'always', // <-- This is not a solution, it just covers up some problem in our code, while disabling the biggest benefit of ReactQueries. Send queries to the server even if the cache has the data
         refetchOnWindowFocus: false,
         refetchOnMount: true,
         staleTime: 1000 * 60 * 5, // 5 minutes
@@ -53,18 +53,12 @@ function App () {
   useEffect(() => {
     console.log('--------- App.jsx loading ---------');
     initializejQuery(() => {
-      console.log('--------- jQuery has been initialized ---------');
+      console.log('--------- jQuery has been initialized, indicates that a new session has been created ---------');
     });
     return () => {
       // Anything in here is fired on component unmount, equiv to componentDidUnmount()
     };
   }, []);
-
-
-  const isAuth = localStorage.getItem('isAuthenticated');
-  if (isAuth) {
-    console.log('======================================== isAuthenticated: "  ', isAuth, ' =============================');
-  }
 
   return (
     <>
@@ -92,7 +86,7 @@ function App () {
                     <Route path="/" element={<Teams />} />
                     <Route path="*" element={<PageNotFound />} />
                   </Routes>
-                  {/* Hack 1/14/25 <Footer /> */}
+                  {/* <Footer /> has problems */}
                   {showDevtools && (
                     <ReactQueryDevtools />
                   )}

--- a/src/js/actions/PersonActions.js
+++ b/src/js/actions/PersonActions.js
@@ -1,34 +1,34 @@
-import Dispatcher from '../common/dispatcher/Dispatcher';
-
-export default {
-  personListRetrieve (searchText = '') {
-    // console.log('PersonActions, personListRetrieve searchText:', searchText);
-    if (searchText) {
-      Dispatcher.loadEndpoint('person-list-retrieve', {
-        searchText,
-      });
-    } else {
-      Dispatcher.loadEndpoint('person-list-retrieve');
-    }
-  },
-
-  personRetrieve (personId = '') {
-    // console.log('PersonActions, personRetrieve personId:', personId);
-    if (personId) {
-      Dispatcher.loadEndpoint('person-retrieve', {
-        personId,
-      });
-    } else {
-      Dispatcher.loadEndpoint('person-retrieve');
-    }
-  },
-
-  personSave (personId = 0, incomingData = {}) {
-    // console.log('PersonActions, personSave personId:', personId, ', incomingData:', incomingData);
-    const data = {
-      personId,
-      ...incomingData,
-    };
-    Dispatcher.loadEndpoint('person-save', data);
-  },
-};
+// import Dispatcher from '../common/dispatcher/Dispatcher';
+//
+// export default {
+//   personListRetrieve (searchText = '') {
+//     // console.log('PersonActions, personListRetrieve searchText:', searchText);
+//     if (searchText) {
+//       Dispatcher.loadEndpoint('person-list-retrieve', {
+//         searchText,
+//       });
+//     } else {
+//       Dispatcher.loadEndpoint('person-list-retrieve');
+//     }
+//   },
+//
+//   personRetrieve (personId = '') {
+//     // console.log('PersonActions, personRetrieve personId:', personId);
+//     if (personId) {
+//       Dispatcher.loadEndpoint('person-retrieve', {
+//         personId,
+//       });
+//     } else {
+//       Dispatcher.loadEndpoint('person-retrieve');
+//     }
+//   },
+//
+//   personSave (personId = 0, incomingData = {}) {
+//     // console.log('PersonActions, personSave personId:', personId, ', incomingData:', incomingData);
+//     const data = {
+//       personId,
+//       ...incomingData,
+//     };
+//     Dispatcher.loadEndpoint('person-save', data);
+//   },
+// };

--- a/src/js/actions/TaskActions.js
+++ b/src/js/actions/TaskActions.js
@@ -1,80 +1,80 @@
-import Dispatcher from '../common/dispatcher/Dispatcher';
-
-export default {
-  taskDefinitionListRetrieve (taskGroupId, searchText = '') {
-    // console.log('TaskActions, taskDefinitionListRetrieve searchText:', searchText);
-    if (searchText) {
-      Dispatcher.loadEndpoint('task-definition-list-retrieve', {
-        taskGroupId,
-        searchText,
-      });
-    } else {
-      Dispatcher.loadEndpoint('task-definition-list-retrieve', {
-        taskGroupId,
-      });
-    }
-  },
-
-  taskDefinitionSave (taskGroupId = -1, taskDefinitionId = -1, incomingData = {}) {
-    // console.log('TaskActions, taskSave taskDefinitionId:', taskDefinitionId, ', incomingData:', incomingData);
-    const data = {
-      taskDefinitionId,
-      taskGroupId,
-      ...incomingData,
-    };
-    Dispatcher.loadEndpoint('task-definition-save', data);
-  },
-
-  taskGroupListRetrieve (searchText = '') {
-    // console.log('TaskActions, taskGroupListRetrieve searchText:', searchText);
-    if (searchText) {
-      Dispatcher.loadEndpoint('task-group-list-retrieve', {
-        searchText,
-      });
-    } else {
-      Dispatcher.loadEndpoint('task-group-list-retrieve');
-    }
-  },
-
-  taskGroupRetrieve (taskGroupId = '') {
-    // console.log('TaskActions, taskGroupRetrieve taskGroupId:', taskGroupId);
-    if (taskGroupId) {
-      Dispatcher.loadEndpoint('task-group-retrieve', {
-        taskGroupId,
-      });
-    } else {
-      Dispatcher.loadEndpoint('task-group-retrieve');
-    }
-  },
-
-  taskGroupSave (taskGroupId = -1, incomingData = {}) {
-    // console.log('TaskActions, taskGroupSave taskGroupId:', taskGroupId, ', incomingData:', incomingData);
-    const data = {
-      taskGroupId,
-      ...incomingData,
-    };
-    Dispatcher.loadEndpoint('task-group-save', data);
-  },
-
-  taskSave (personId = -1, taskDefinitionId = -1, taskGroupId = -1, incomingData = {}) {
-    // console.log('TaskActions, taskSave personId:', personId, ', taskDefinitionId:', taskDefinitionId, ', ', taskGroupId:', taskGroupId, ', incomingData:', incomingData);
-    const data = {
-      personId,
-      taskDefinitionId,
-      taskGroupId,
-      ...incomingData,
-    };
-    Dispatcher.loadEndpoint('task-save', data);
-  },
-
-  taskStatusListRetrieve (personIdList = []) {
-    // console.log('TaskActions, taskStatusListRetrieve personIdList:', personIdList);
-    if (personIdList) {
-      Dispatcher.loadEndpoint('task-status-list-retrieve', {
-        personIdList,
-      });
-    } else {
-      Dispatcher.loadEndpoint('task-status-list-retrieve');
-    }
-  },
-};
+// import Dispatcher from '../common/dispatcher/Dispatcher';
+//
+// export default {
+//   taskDefinitionListRetrieve (taskGroupId, searchText = '') {
+//     // console.log('TaskActions, taskDefinitionListRetrieve searchText:', searchText);
+//     if (searchText) {
+//       Dispatcher.loadEndpoint('task-definition-list-retrieve', {
+//         taskGroupId,
+//         searchText,
+//       });
+//     } else {
+//       Dispatcher.loadEndpoint('task-definition-list-retrieve', {
+//         taskGroupId,
+//       });
+//     }
+//   },
+//
+//   taskDefinitionSave (taskGroupId = -1, taskDefinitionId = -1, incomingData = {}) {
+//     // console.log('TaskActions, taskSave taskDefinitionId:', taskDefinitionId, ', incomingData:', incomingData);
+//     const data = {
+//       taskDefinitionId,
+//       taskGroupId,
+//       ...incomingData,
+//     };
+//     Dispatcher.loadEndpoint('task-definition-save', data);
+//   },
+//
+//   taskGroupListRetrieve (searchText = '') {
+//     // console.log('TaskActions, taskGroupListRetrieve searchText:', searchText);
+//     if (searchText) {
+//       Dispatcher.loadEndpoint('task-group-list-retrieve', {
+//         searchText,
+//       });
+//     } else {
+//       Dispatcher.loadEndpoint('task-group-list-retrieve');
+//     }
+//   },
+//
+//   taskGroupRetrieve (taskGroupId = '') {
+//     // console.log('TaskActions, taskGroupRetrieve taskGroupId:', taskGroupId);
+//     if (taskGroupId) {
+//       Dispatcher.loadEndpoint('task-group-retrieve', {
+//         taskGroupId,
+//       });
+//     } else {
+//       Dispatcher.loadEndpoint('task-group-retrieve');
+//     }
+//   },
+//
+//   taskGroupSave (taskGroupId = -1, incomingData = {}) {
+//     // console.log('TaskActions, taskGroupSave taskGroupId:', taskGroupId, ', incomingData:', incomingData);
+//     const data = {
+//       taskGroupId,
+//       ...incomingData,
+//     };
+//     Dispatcher.loadEndpoint('task-group-save', data);
+//   },
+//
+//   taskSave (personId = -1, taskDefinitionId = -1, taskGroupId = -1, incomingData = {}) {
+//     // console.log('TaskActions, taskSave personId:', personId, ', taskDefinitionId:', taskDefinitionId, ', ', taskGroupId:', taskGroupId, ', incomingData:', incomingData);
+//     const data = {
+//       personId,
+//       taskDefinitionId,
+//       taskGroupId,
+//       ...incomingData,
+//     };
+//     Dispatcher.loadEndpoint('task-save', data);
+//   },
+//
+//   taskStatusListRetrieve (personIdList = []) {
+//     // console.log('TaskActions, taskStatusListRetrieve personIdList:', personIdList);
+//     if (personIdList) {
+//       Dispatcher.loadEndpoint('task-status-list-retrieve', {
+//         personIdList,
+//       });
+//     } else {
+//       Dispatcher.loadEndpoint('task-status-list-retrieve');
+//     }
+//   },
+// };

--- a/src/js/actions/TeamActions.js
+++ b/src/js/actions/TeamActions.js
@@ -1,54 +1,54 @@
-import Dispatcher from '../common/dispatcher/Dispatcher';
-import PersonStore from '../stores/PersonStore'; // eslint-disable-line import/no-cycle
-import TeamStore from '../stores/TeamStore'; // eslint-disable-line import/no-cycle
-
-export default {
-  addPersonToTeam (personId, teamId) {
-    // console.log('TeamActions, addPersonToTeam personId:', personId, ', teamId:', teamId);
-    const teamMemberFirstName = PersonStore.getFirstName(personId) || '';
-    const teamMemberLastName = PersonStore.getLastName(personId) || '';
-    const teamName = TeamStore.getTeamName(teamId) || '';
-    const data = {
-      personId,
-      teamId,
-      teamMemberFirstName,
-      teamMemberLastName,
-      teamName,
-    };
-    Dispatcher.loadEndpoint('add-person-to-team', data);
-  },
-
-  removePersonFromTeam (personId, teamId) {
-    // console.log('TeamActions, removePersonFromTeam personId:', personId, ', teamId:', teamId);
-    const data = {
-      personId,
-      teamId,
-    };
-    Dispatcher.loadEndpoint('remove-person-from-team', data);
-  },
-
-  teamRetrieve (teamId = '') {
-    // console.log('TeamActions, teamRetrieve teamId:', teamId);
-    if (teamId) {
-      Dispatcher.loadEndpoint('team-retrieve', {
-        teamId,
-      });
-    } else {
-      Dispatcher.loadEndpoint('team-retrieve');
-    }
-  },
-
-  teamListRetrieve () {
-    // console.log('TeamActions, teamListRetrieve');
-    Dispatcher.loadEndpoint('team-list-retrieve');
-  },
-
-  teamSave (teamId = '', incomingData = {}) {
-    // console.log('PersonActions, teamSave teamId:', teamId, ', incomingData:', incomingData);
-    const data = {
-      teamId,
-      ...incomingData,
-    };
-    Dispatcher.loadEndpoint('team-save', data);
-  },
-};
+// import Dispatcher from '../common/dispatcher/Dispatcher';
+// import PersonStore from '../stores/PersonStore'; // eslint-disable-line import/no-cycle
+// import TeamStore from '../stores/TeamStore'; // eslint-disable-line import/no-cycle
+//
+// export default {
+//   addPersonToTeam (personId, teamId) {
+//     // console.log('TeamActions, addPersonToTeam personId:', personId, ', teamId:', teamId);
+//     const teamMemberFirstName = PersonStore.getFirstName(personId) || '';
+//     const teamMemberLastName = PersonStore.getLastName(personId) || '';
+//     const teamName = TeamStore.getTeamName(teamId) || '';
+//     const data = {
+//       personId,
+//       teamId,
+//       teamMemberFirstName,
+//       teamMemberLastName,
+//       teamName,
+//     };
+//     Dispatcher.loadEndpoint('add-person-to-team', data);
+//   },
+//
+//   removePersonFromTeam (personId, teamId) {
+//     // console.log('TeamActions, removePersonFromTeam personId:', personId, ', teamId:', teamId);
+//     const data = {
+//       personId,
+//       teamId,
+//     };
+//     Dispatcher.loadEndpoint('remove-person-from-team', data);
+//   },
+//
+//   teamRetrieve (teamId = '') {
+//     // console.log('TeamActions, teamRetrieve teamId:', teamId);
+//     if (teamId) {
+//       Dispatcher.loadEndpoint('team-retrieve', {
+//         teamId,
+//       });
+//     } else {
+//       Dispatcher.loadEndpoint('team-retrieve');
+//     }
+//   },
+//
+//   teamListRetrieve () {
+//     // console.log('TeamActions, teamListRetrieve');
+//     Dispatcher.loadEndpoint('team-list-retrieve');
+//   },
+//
+//   teamSave (teamId = '', incomingData = {}) {
+//     // console.log('PersonActions, teamSave teamId:', teamId, ', incomingData:', incomingData);
+//     const data = {
+//       teamId,
+//       ...incomingData,
+//     };
+//     Dispatcher.loadEndpoint('team-save', data);
+//   },
+// };

--- a/src/js/components/Drawers/AddTeamDrawer.jsx
+++ b/src/js/components/Drawers/AddTeamDrawer.jsx
@@ -14,7 +14,7 @@ const AddTeamDrawer = () => {
       drawerId="addTeamDrawer"
       drawerOpenGlobalVariableName="addTeamDrawerOpen"
       mainContentJsx={<AddTeamDrawerMainContent />}
-      headerTitleJsx={getAppContextValue('AddTeamDrawerLabel')}
+      headerTitleJsx={<>{getAppContextValue('AddTeamDrawerLabel')}</>}
       headerFixedJsx={<></>}
     />
   );

--- a/src/js/components/Drawers/EditQuestionDrawer.jsx
+++ b/src/js/components/Drawers/EditQuestionDrawer.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { renderLog } from '../../common/utils/logging';
 import { useConnectAppContext } from '../../contexts/ConnectAppContext';
 import EditQuestionDrawerMainContent from '../Questionnaire/EditQuestionDrawerMainContent';
@@ -8,19 +8,10 @@ const EditQuestionDrawer = () => {
   renderLog('EditQuestionDrawer');
   const { getAppContextValue } = useConnectAppContext();
 
-  const [headerTitleJsx, setHeaderTitleJsx] = useState(<></>);
+  const question = getAppContextValue('selectedQuestion');
+  const markup = question && question.id >= 0 ? <>Edit Question</> : <>Add Question</>;
+  const [headerTitleJsx] = useState(markup);
   const [headerFixedJsx] = useState(<></>);
-
-  useEffect(() => {
-    // console.log('EditQuestionDrawer: Context value changed:', true);
-    const question = getAppContextValue('selectedQuestion');
-    // if (question && question.id >= 0) {
-    //   setHeaderTitleJsx(<>Edit Question</>);
-    // } else {
-    //   setHeaderTitleJsx(<>Add Question</>);
-    // }
-  });
-  // }, [getAppContextValue]);  // TODO DALE: commented out for now to avoid infinite loop
 
   return (
     <DrawerTemplateA

--- a/src/js/components/Drawers/EditQuestionnaireDrawer.jsx
+++ b/src/js/components/Drawers/EditQuestionnaireDrawer.jsx
@@ -1,15 +1,15 @@
-import React, { useEffect, useState } from 'react';
-import { useConnectAppContext } from '../../contexts/ConnectAppContext';
-import DrawerTemplateA from './DrawerTemplateA';
+import React, { useState } from 'react';
 import { renderLog } from '../../common/utils/logging';
+import { useConnectAppContext } from '../../contexts/ConnectAppContext';
 import EditQuestionnaireDrawerMainContent from '../Questionnaire/EditQuestionnaireDrawerMainContent';
+import DrawerTemplateA from './DrawerTemplateA';
 
 
 const EditQuestionnaireDrawer = () => {
   renderLog('EditQuestionnaireDrawer');
   const { getAppContextValue } = useConnectAppContext();
 
-  const selected = getAppContextValue('selectedQuestionnaire');
+  const selected = getAppContextValue('selectedQuestion');
   const [headerTitleJsx] = useState(selected ? <>Edit Questionnaire</> : <>Add Questionnaire</>);
   const [headerFixedJsx] = useState(<></>);
 

--- a/src/js/components/Navigation/Header.jsx
+++ b/src/js/components/Navigation/Header.jsx
@@ -1,9 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
-import { isCordova } from '../../common/utils/isCordovaOrWebApp';
-import { handleResize } from '../../common/utils/isMobileScreenSize';
 import { renderLog } from '../../common/utils/logging';
-import { messageService } from '../../stores/AppObservableStore';
 import cordovaTopHeaderTopMargin from '../../utils/cordovaTopHeaderTopMargin';
 import { HeadroomWrapper } from '../Style/pageLayoutStyles';
 import IPhoneSpacer from '../Widgets/IPhoneSpacer';
@@ -12,36 +9,7 @@ import HeaderBar from './HeaderBar';
 
 const Header = ({ hideHeader }) => {
   renderLog('Header');  // Set LOG_RENDER_EVENTS to log all renders
-  const [pageHeaderClasses, setPageHeaderClasses] = useState('');
-
-  const handleResizeLocal = () => {
-    if (handleResize('Header')) {
-      // this.setState({});
-    }
-  };
-
-  const onAppObservableStoreChange = () => {
-    // console.log('------ Header, onAppObservableStoreChange received: ', msg);
-  };
-
-  React.useEffect(() => {
-    const appStateSubscription = messageService.getMessage().subscribe(() => onAppObservableStoreChange());
-    onAppObservableStoreChange();
-    window.addEventListener('resize', handleResizeLocal);
-
-    let pageHeaderClassesTemp = '';
-    if (isCordova()) {
-      pageHeaderClassesTemp = '';   // Abandoning the main.css styles if cordova 10/2/2021
-    }
-    // Non-functional class, to provide a reminder about how to debug top margins
-    pageHeaderClassesTemp += pageHeaderClassesTemp.length ? ' cordovaTopHeaderTopMargin' : 'cordovaTopHeaderTopMargin';
-    setPageHeaderClasses(pageHeaderClassesTemp);
-
-    return () => {
-      appStateSubscription.unsubscribe();
-      window.removeEventListener('resize', handleResizeLocal);
-    };
-  }, []);
+  const [pageHeaderClasses] = useState('');
 
   return (
     <div id="app-header">

--- a/src/js/components/Person/AddPersonDrawerMainContent.jsx
+++ b/src/js/components/Person/AddPersonDrawerMainContent.jsx
@@ -22,8 +22,7 @@ const AddPersonDrawerMainContent = () => {
   const [allStaffList] = useState(getAppContextValue('allStaffList'));
   const [remainingStaffToAdd, setRemainingStaffToAdd] = useState(getAppContextValue('allStaffList'));
   const [searchResultsList, setSearchResultsList] = useState(undefined);
-  // eslint-disable-next-line no-unused-vars
-  const [thisTeamsCurrentMembersList, setThisTeamsCurrentMembersList] = useState([]);
+  const [thisTeamsCurrentMembersList] = useState(getAppContextValue('addPersonDrawerTeamMemberList'));
   // eslint-disable-next-line no-unused-vars
   const [teamId, setTeamId] = useState(getAppContextValue('teamId'));
   // eslint-disable-next-line no-unused-vars
@@ -33,22 +32,6 @@ const AddPersonDrawerMainContent = () => {
   const [addPersonDrawerOpen] = useState(getAppContextValue('addPersonDrawerOpen'));
 
   const searchStringRef = useRef('');
-
-  // let memberList = [];
-  // const teamListFromContext = getAppContextValue('teamListNested');
-  // const teamListFromContext = GetTeamListArray();
-  // if (teamListFromContext  && thisTeamsCurrentMembersList.length === 0 && teamName === '') {
-  //   const oneTeam = teamListFromContext.find((team) => team.id === parseInt(teamId));
-  //   setTeamName(oneTeam.teamName);
-  //   setTeamId(oneTeam.id);
-  //
-  //   if (oneTeam && oneTeam.teamMemberList.length > 0) {
-  //     memberList = oneTeam.teamMemberList;
-  //     setThisTeamsCurrentMembersList(memberList);
-  //   }
-  // } else {
-  //   // console.log('no teamListFromContext yet!');
-  // }
 
   const initializeRemainingStaffToAddList = () => {
     console.log('initializeTheRemainingStaffToAddListList in AddPersonDrawerMainContent');
@@ -115,7 +98,10 @@ const AddPersonDrawerMainContent = () => {
     }
   };
 
-  const displayList = searchResultsList || remainingStaffToAdd || [];
+  // TODO: Need to deal with preferred name searching and display, very possible but it will get more complicated
+  let displayList = searchResultsList || remainingStaffToAdd || [];
+  displayList = displayList.filter((staff) => staff.firstName.length || staff.lastName.length);
+
   return (
     <AddPersonDrawerMainContentWrapper>
       <SearchBarWrapper>

--- a/src/js/components/Person/EditPersonForm.jsx
+++ b/src/js/components/Person/EditPersonForm.jsx
@@ -7,18 +7,18 @@ import { renderLog } from '../../common/utils/logging';
 import webAppConfig from '../../config';
 import { useConnectAppContext } from '../../contexts/ConnectAppContext';
 import makeRequestParams from '../../react-query/makeRequestParams';
-// import { usePersonSaveMutation } from '../../react-query/mutations';
-import { useGetPersonById, usePersonSave } from '../../models/PersonModel';
+import { usePersonSaveMutation } from '../../react-query/mutations';
+// import { useGetPersonById, usePersonSave } from '../../models/PersonModel';
 
 const EditPersonForm = ({ classes }) => {
   renderLog('EditPersonForm');
   const { getAppContextValue } = useConnectAppContext();
-  // const { mutate } = usePersonSaveMutation();
-  const { mutate: personSave } = usePersonSave();
+  const { mutate } = usePersonSaveMutation();
+  // const { mutate: personSave } = usePersonSave();
 
   const [saveButtonActive, setSaveButtonActive] = useState(false);
-  // const [initialPerson] = useState(getAppContextValue('personDrawersPerson'));
-  const [initialPerson] = useState(useGetPersonById(getAppContextValue('personDrawersPersonId')));
+  const [initialPerson] = useState(getAppContextValue('personDrawersPerson'));
+  // const [initialPerson] = useState(useGetPersonById(getAppContextValue('personDrawersPersonId')));
   const [activePerson, setActivePerson] = useState({ ...initialPerson });
 
   const emailPersonal = useRef('');
@@ -54,8 +54,8 @@ const EditPersonForm = ({ classes }) => {
       personId: activePerson.id,
     };
 
-    // mutate(makeRequestParams(plainParams, data));
-    personSave(makeRequestParams(plainParams, data));
+    mutate(makeRequestParams(plainParams, data));
+    // personSave(makeRequestParams(plainParams, data));
     setSaveButtonActive(false);
   };
 
@@ -78,7 +78,7 @@ const EditPersonForm = ({ classes }) => {
           defaultValue={activePerson.firstNamePreferred || ''}
           id="firstNamePreferredToBeSaved"
           inputRef={firstNamePreferred}
-          label="Preferred Name (if different from legal)"
+          label="Preferred FIRST Name (if different from legal)"
           margin="dense"
           name="firstNamePreferred"
           onChange={() => setSaveButtonActive(true)}

--- a/src/js/components/Person/PersonSummaryRow.jsx
+++ b/src/js/components/Person/PersonSummaryRow.jsx
@@ -5,16 +5,16 @@ import styled from 'styled-components';
 import DesignTokenColors from '../../common/components/Style/DesignTokenColors';
 import { renderLog } from '../../common/utils/logging';
 import { useConnectAppContext } from '../../contexts/ConnectAppContext';
-import { useGetFullNamePreferred } from '../../models/PersonModel';
-import { useRemoveTeamMemberMutation } from '../../models/TeamModel';
-// import useGetFullNamePreferredReactQuery from '../../react-query/useGetFullNamePreferredReactQuery';
-// import { useRemoveTeamMemberMutation } from '../../react-query/mutations';
+import { useRemoveTeamMemberMutation } from '../../react-query/mutations';
 import { DeleteStyled, EditStyled } from '../Style/iconStyles';
+// import { useRemoveTeamMemberMutationDiverged } from '../../models/TeamModel';
 
 
 const PersonSummaryRow = ({ person, rowNumberForDisplay, teamId }) => {
   renderLog('PersonSummaryRow');  // Set LOG_RENDER_EVENTS to log all renders
-  // const [person, setPerson] = useState(useGetPersonById(personId));
+  // console.log('PersonSummaryRow location: ', person && person.location);
+
+  // const [person, setPerson] = useState(useGetPersonById(personId));  2/5/2025 does not work
   const { setAppContextValue } = useConnectAppContext();
   const { mutate } = useRemoveTeamMemberMutation();
 
@@ -26,14 +26,14 @@ const PersonSummaryRow = ({ person, rowNumberForDisplay, teamId }) => {
   const editPersonClick = (hasEditRights = true) => {
     if (hasEditRights) {
       setAppContextValue('editPersonDrawerOpen', true);
-      // setAppContextValue('personDrawersPerson', person);
+      setAppContextValue('personDrawersPerson', person);
       setAppContextValue('personDrawersPersonId', person.personId);
     }
   };
 
   const personProfileClick = () => {
     setAppContextValue('personProfileDrawerOpen', true);
-    // setAppContextValue('personDrawersPerson', person);
+    setAppContextValue('personDrawersPerson', person);
     setAppContextValue('personDrawersPersonId', person.personId);
   };
 
@@ -65,7 +65,8 @@ const PersonSummaryRow = ({ person, rowNumberForDisplay, teamId }) => {
         }}
         width={200}
       >
-        {useGetFullNamePreferred(person.personId)}
+        {`${person.firstName} ${person.lastName}`}
+        {/* useGetFullNamePreferred(person.personId) 2/6/25 currently if you save a first name preferred, it shows up here, but will not be searchable on add team member If you */}
       </PersonCell>
       <PersonCell id={`location-personId-${person.personId}`} $smallFont width={300}>
         {person.location}

--- a/src/js/components/Team/TeamHeader.jsx
+++ b/src/js/components/Team/TeamHeader.jsx
@@ -1,7 +1,6 @@
 import { withStyles } from '@mui/styles';
-import { useQueryClient } from '@tanstack/react-query';
 import PropTypes from 'prop-types';
-import React, { useState } from 'react';
+import React from 'react';
 import { Link } from 'react-router';
 import styled from 'styled-components';
 import { renderLog } from '../../common/utils/logging';
@@ -16,7 +15,10 @@ const TeamHeader = ({ classes, showHeaderLabels, showIcons, team }) => {
   const { getAppContextValue, setAppContextValue } = useConnectAppContext();
   const { mutate } = useRemoveTeamMutation();
 
-  const [teamLocal] = useState(useQueryClient(team || getAppContextValue('teamForAddTeamDrawer')));
+  let teamLocal = team;
+  if (!teamLocal || !teamLocal.teamName) {
+    teamLocal = getAppContextValue('teamForAddTeamDrawer');
+  }
 
   const removeTeamClick = () => {
     console.log('removeTeamMutation team: ', teamLocal.id);
@@ -30,6 +32,7 @@ const TeamHeader = ({ classes, showHeaderLabels, showIcons, team }) => {
     setAppContextValue('teamForAddTeamDrawer', teamLocal);
   };
 
+  // console.log('TeamHeader teamLocal.teamName ', teamLocal.teamName);
   return (
     <OneTeamHeader>
       {/* Width (below) of this TeamHeaderCell comes from the combined widths of the first x columns in TeamMemberList */}

--- a/src/js/components/Team/TeamMemberList.jsx
+++ b/src/js/components/Team/TeamMemberList.jsx
@@ -80,6 +80,7 @@ const TeamMemberList = ({ teamId, team }) => { // teamMemberList
 };
 TeamMemberList.propTypes = {
   teamId: PropTypes.any.isRequired,
+  team: PropTypes.object.isRequired,
 };
 
 const styles = (theme) => ({

--- a/src/js/components/Team/TeamMemberList.jsx
+++ b/src/js/components/Team/TeamMemberList.jsx
@@ -3,41 +3,73 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { renderLog } from '../../common/utils/logging';
-import PersonSummaryRow from '../Person/PersonSummaryRow';
-import {
-  GetTeamMembersListByTeamId,
-  // useGetTeamMembersListByTeamId,
-} from '../../models/TeamModel';
 import { useConnectAppContext } from '../../contexts/ConnectAppContext';
+import { getTeamMembersListByTeamId } from '../../models/TeamModel';
+import { METHOD, useFetchData } from '../../react-query/WeConnectQuery';
+import PersonSummaryRow from '../Person/PersonSummaryRow';
 
-const TeamMemberList = ({ teamId }) => { // teamMemberList
+// DO NOT REMOVE PASSED in TEAM
+const TeamMemberList = ({ teamId, team }) => { // teamMemberList
   renderLog('TeamMemberList');
   const { apiDataCache } = useConnectAppContext();
   const { allPeopleCache, allTeamsCache } = apiDataCache;
-  // const [teamMemberList, setTeamMemberList] = useState(useGetTeamMembersListByTeamId(teamId));
-  const [teamMemberList, setTeamMemberList] = useState([]);
+  const [teamMemberListApiDataCache, setTeamMemberListApiDataCache] = useState([]);
+  const [teamMemberListReactQuery, setTeamMemberListReactQuery] = useState(team.teamMemberList || []);
   // const teamMemberList = useGetTeamMembersListByTeamId(teamId);
   // console.log('TeamMemberList teamMemberList:', teamMemberList);
 
+  const { data: dataTLR, isSuccess: isSuccessTLR, isFetching: isFetchingTLR } = useFetchData(['team-list-retrieve'], {}, METHOD.GET);
+  console.log('useFetchData in TeamMemberList:', dataTLR, isSuccessTLR, isFetchingTLR);
+  useEffect(() => {
+    console.log('effect of useFetchData in TeamMemberList useEffect:', dataTLR, isSuccessTLR, isFetchingTLR);
+    if (dataTLR !== undefined && isSuccessTLR) {
+      const oneTeam = dataTLR.teamList.find((tm) => tm.teamId === parseInt(teamId));
+      if (oneTeam) {  // We might have just deleted the team
+        setTeamMemberListReactQuery(oneTeam.teamMemberList);
+      }
+    }
+  }, [dataTLR, isSuccessTLR]);
+
   useEffect(() => {
     // console.log(`TeamMemberList useEffect teamId: ${teamId} apiDataCache:`, apiDataCache);
-    const updatedTeamMemberList = GetTeamMembersListByTeamId(teamId, apiDataCache);
+    const updatedTeamMemberList = getTeamMembersListByTeamId(teamId, apiDataCache);
     // console.log(`TeamMemberList useEffect teamId: ${teamId} updatedTeamMemberList:`, updatedTeamMemberList);
-    setTeamMemberList(updatedTeamMemberList);
+    setTeamMemberListApiDataCache(updatedTeamMemberList);
   }, [allPeopleCache, allTeamsCache, teamId]);
+
+  // const oneTeam = teamList.find((tm) => tm.teamId === parseInt(teamId));
+  console.log('Cached by ReactQuery teamMemberList: ', teamMemberListReactQuery);
+  console.log('Cached by apiDataCache teamMemberList: ', teamMemberListApiDataCache);
+
+  // DO NOT REMOVE: diffs the ReactQuery cache results with the ApiDataCache
+  if (teamMemberListReactQuery && teamMemberListApiDataCache) {
+    for (let i = 0; i < teamMemberListReactQuery.length; i++) {
+      Object.keys(teamMemberListReactQuery[i]).forEach((key) => {
+        if (key !== 'id' && !key.startsWith('date')) {
+          const valReactQueryCache = teamMemberListReactQuery && teamMemberListReactQuery[i] && teamMemberListReactQuery[i][key];
+          const valApiCacheQuery = teamMemberListApiDataCache && teamMemberListApiDataCache[i] && teamMemberListApiDataCache[i][key];
+          if (valApiCacheQuery !== valReactQueryCache) {
+            console.log(`ERROR: teamMemberList authoritative ReactQuery cache for key: ${key} value: '${valReactQueryCache}' does not match processed cache value: '${valApiCacheQuery}'`);
+          }
+        }
+      });
+    }
+  }
 
   return (
     <TeamMembersWrapper>
-      {teamMemberList.map((person, index) => {
-        // console.log(`TeamMemberList teamId: ${teamId}, person:`, person);
+      {teamMemberListReactQuery.map((person, index) => {
+        if (teamId === 10) console.log(`TeamMemberList teamId: ${teamId}, person: ${person} location ${person.location}`);
         if (person) {
           return (
-            <PersonSummaryRow
-              key={`teamMember-${teamId}-${person.id}`}
-              person={person}
-              rowNumberForDisplay={index + 1}
-              teamId={teamId}
-            />
+            <>
+              <PersonSummaryRow
+                key={`teamMember-${teamId}-${person.id}`}
+                person={person}
+                rowNumberForDisplay={index + 1}
+                teamId={teamId}
+              />
+            </>
           );
         } else {
           return null; // Empty row for non-existing members

--- a/src/js/contexts/ConnectAppContext.jsx
+++ b/src/js/contexts/ConnectAppContext.jsx
@@ -12,6 +12,7 @@ const ConnectDispatch = createContext(null);
 
 function apiDataCacheReducer (apiDataCache, action) {
   let revisedApiDataCache = { ...apiDataCache };
+  // console.log('^^^^^^^^ apiDataReducer called with key: ', action.key);
   switch (action.type) {
     case 'updateByKeyValue': {
       revisedApiDataCache = { ...revisedApiDataCache, [action.key]: action.value };
@@ -55,7 +56,7 @@ export const ConnectAppContextProvider = ({ children }) => {
   // This is not currently the right place to pass these values, but I'm saving these here for the next 30 days until we work out the correct place.
   // {
   //   cacheTime: 0,
-  //   networkMode: 'no-cache',
+  //   networkMode: 'no-cache', <-- This is not a solution, it just covers up some problem in our code, while disabling the biggest benefit of ReactQueries.
   //   refetchOnMount: true,
   //   refetchOnWindowFocus: true,
   //   refetchInterval: 0,
@@ -93,7 +94,6 @@ export const ConnectAppContextProvider = ({ children }) => {
     }
   }, [dataAuth, isSuccessAuth]);
 
-
   return (
     <ConnectAppContext.Provider value={{ apiDataCache, getAppContextData, setAppContextValue, getAppContextValue, setAppContextValuesInBulk }}>
       <ConnectDispatch.Provider value={dispatch}>
@@ -114,33 +114,3 @@ export function useConnectAppContext () {
 export function useConnectDispatch () {
   return useContext(ConnectDispatch);
 }
-
-
-
-
-
-
-
-// Replaces AppObservableStore.js
-// export const ConnectAppContext = createContext({ value: undefined, loadValue: () => console.log('Default function') });
-//
-//
-// // https://stackoverflow.com/questions/57819211/how-to-set-a-value-with-usecontext
-// // eslint-disable-next-line react/prop-types
-// export const WeProvider = ({ children }) => {
-//   const [value, setAppContextValue] = useState(undefined);
-//
-//   return (
-//     <ConnectAppContext.Provider
-//       value={{
-//         value,
-//         loadAppContextValue: (currentValue) => {
-//           setAppContextValue(currentValue);
-//         },
-//       }}
-//     >
-//       {children}
-//     </ConnectAppContext.Provider>
-//   );
-// };
-//

--- a/src/js/models/PersonModel.jsx
+++ b/src/js/models/PersonModel.jsx
@@ -33,7 +33,7 @@ export const useGetFullNamePreferred = (personId) => {
   return fullName;
 };
 
-// Needed to avoid Dependency cycle problem
+// Needed to avoid Dependency cycle problem, and to get this string from within maps
 export const getFullNamePreferredPerson = (person) => {
   let fullName = '';
   if (person.id >= 0) {
@@ -60,7 +60,7 @@ export const usePersonSave = () => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (params) => weConnectQueryFn('person-save', params, METHOD.GET),
-    networkMode: 'always', // Send queries to the server even if the cache has the data
+    // networkMode: 'always', // <- This is not a solution, it just covers up some problem in our code, while disabling the biggest benefit of ReactQueries. Send queries to the server even if the cache has the data
     onError: (error) => {
       console.log('onError in usePersonSave: ', error);
       queryClient.refetchQueries({ queryKey: ['person-list-retrieve'], refetchType: 'active', exact: true, force: true })

--- a/src/js/models/TaskModel.jsx
+++ b/src/js/models/TaskModel.jsx
@@ -6,6 +6,7 @@ import isEqual from 'lodash-es/isEqual';
 
 // This is called after making this fetchData request:
 // const taskStatusListRetrieveResults = useFetchData(['task-status-list-retrieve'], { personIdList: personIdsList });
+// eslint-disable-next-line import/prefer-default-export
 export function TaskStatusListRetrieveDataCapture (
   incomingRetrieveResults = {},
   apiDataCache = {},

--- a/src/js/models/TeamModel.jsx
+++ b/src/js/models/TeamModel.jsx
@@ -8,6 +8,8 @@ export const useGetTeamById = (teamId) => {
   const { apiDataCache } = useConnectAppContext();
   const { allTeamsCache } = apiDataCache;
   // console.log('useGetTeamById teamId:', teamId, ', allTeamsCache:', allTeamsCache);
+  // console.log('||||||| useGetTeamById teamId:', teamId, ', allTeamsCache[2].teamName:', allTeamsCache && allTeamsCache && allTeamsCache[2].teamName);
+
   if (allTeamsCache) {
     return allTeamsCache[teamId] || {};
   } else {
@@ -15,7 +17,7 @@ export const useGetTeamById = (teamId) => {
   }
 };
 
-export const GetTeamMembersListByTeamId = (teamId, apiDataCache) => {
+export const getTeamMembersListByTeamId = (teamId, apiDataCache) => {
   const { allPeopleCache, allTeamMembersCache } = apiDataCache;
   if (!allTeamMembersCache || !allTeamMembersCache[teamId]) {
     return [];
@@ -43,6 +45,7 @@ export function TeamListRetrieveDataCapture (
   apiDataCache = {},
   dispatch,
 ) {
+  // console.log('||||||| TeamListRetrieveDataCapture should be called after useFetchData([\'team-list-retrieve\'], {})')
   const { data, isSuccess } = incomingRetrieveResults;
   const allTeamMembersCache = apiDataCache.allTeamMembersCache || {};
   const allTeamsCache = apiDataCache.allTeamsCache || {};
@@ -107,6 +110,7 @@ export function TeamListRetrieveDataCapture (
         }
       }
       if (newTeamMemberDataReceived) {
+        // console.log('newTeamMemberDataReceived, dispatching allTeamMembersCache');
         dispatch({ type: 'updateByKeyValue', key: 'allTeamMembersCache', value: allTeamMembersCacheNew });
         changeResults.allTeamMembersCache = allTeamMembersCacheNew;
         changeResults.allTeamMembersCacheChanged = true;
@@ -121,11 +125,12 @@ export function TeamListRetrieveDataCapture (
   return changeResults;
 }
 
-export const useRemoveTeamMemberMutation = () => {
+// 2/6/24 Doesn't work and previously used the same function name as the working one in mutations.js
+export const useRemoveTeamMemberMutationDiverged = () => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (params) => weConnectQueryFn('remove-person-from-team', params),
-    networkMode: 'always', // Send queries to the server even if the cache has the data
+    // networkMode: 'always', // <-- This is not a solution, it just covers up some problem in our code, while disabling the biggest benefit of ReactQueries.  Send queries to the server even if the cache has the data
     onError: (error) => {
       console.log('onError in useRemoveTeamMemberMutation: ', error);
       queryClient.refetchQueries({ queryKey: ['team-list-retrieve'], refetchType: 'active', exact: true, force: true })

--- a/src/js/models/initialApiDataCache.js
+++ b/src/js/models/initialApiDataCache.js
@@ -1,6 +1,7 @@
 // Moved to a separate file that does not include ConnectAppContext.jsx to avoid a "Dependency cycle"
 const initialApiDataCache = () => {
   // These are the "AppContextValues" (i.e., global state variables) used in the PersonModel
+  console.log('initialApiDataCache called');  // This is worth logging, to see if we are reinitializing the apiDataCache unintentionally
   const initialGlobalPersonVariables = {
     allPeopleCache: {}, // This is a dictionary key: personId, value: person dict
     mostRecentPersonIdSaved: -1,

--- a/src/js/pages/TeamHome.jsx
+++ b/src/js/pages/TeamHome.jsx
@@ -22,6 +22,7 @@ const TeamHome = ({ classes }) => {
 
   const params  = useParams();
   const [team, setTeam] = useState(useGetTeamById(convertToInteger(params.teamId)));
+  const [teamMemberLists, setTeamMemberLists] = useState([]);
   const [teamId] = useState(convertToInteger(params.teamId));
 
   // const updateTeam = (tList) => {
@@ -35,6 +36,7 @@ const TeamHome = ({ classes }) => {
   useEffect(() => {
     // console.log('useFetchData team-list-retrieve in TeamHome useEffect:', teamListRetrieveResults);
     if (teamListRetrieveResults) {
+      setTeamMemberLists(teamListRetrieveResults.data);
       // console.log('In useEffect apiDataCache:', apiDataCache);
       // const changeResults =
       TeamListRetrieveDataCapture(teamListRetrieveResults, apiDataCache, dispatch);
@@ -65,6 +67,8 @@ const TeamHome = ({ classes }) => {
     setAppContextValue('addPersonDrawerOpen', true);
     setAppContextValue('addPersonDrawerTeam', team);
     setAppContextValue('teamId', team.id);
+    const teamWithEmbeddedMemberList = (teamMemberLists && teamMemberLists.teamList.filter((list) => list.id === team.id)[0]) || [];
+    setAppContextValue('addPersonDrawerTeamMemberList', teamWithEmbeddedMemberList && teamWithEmbeddedMemberList.teamMemberList);
   };
 
   return (
@@ -97,7 +101,8 @@ const TeamHome = ({ classes }) => {
               // showHeaderLabels={(teamMemberList && teamMemberList.length > 0)}
               showIcons={false}
             />
-            <TeamMemberList teamId={teamId} />
+            {/* PLEASE DO NOT REMOVE PASSED team */}
+            <TeamMemberList teamId={teamId} team={team} />
           </>
         )}
         <Button
@@ -105,6 +110,7 @@ const TeamHome = ({ classes }) => {
           color="primary"
           variant="outlined"
           onClick={addTeamMemberClick}
+          sx={{ marginTop: '30px' }}
         >
           Add Team Member
         </Button>

--- a/src/js/react-query/TeamsQueryProcessing.js
+++ b/src/js/react-query/TeamsQueryProcessing.js
@@ -1,18 +1,18 @@
 // eslint-disable-next-line  arrow-body-style
-export const getTeamList = (teamListData) => {
-  // const teamListRaw = teamListData.teamList;
-
-  // Copied from TeamStore, this code does nothing
-  // const teamList = [];
-  // let teamFiltered;
-  // let teamRaw;
-  // for (let i = 0; i < teamListRaw.length; i++) {
-  //   teamRaw = teamListRaw[i];
-  //   teamFiltered = teamRaw;
-  //   teamList.push(teamFiltered);
-  // }
-  return teamListData.teamList;
-};
+// export const getTeamList = (teamListData) => {
+//   // const teamListRaw = teamListData.teamList;
+//
+//   // Copied from TeamStore, this code does nothing
+//   // const teamList = [];
+//   // let teamFiltered;
+//   // let teamRaw;
+//   // for (let i = 0; i < teamListRaw.length; i++) {
+//   //   teamRaw = teamListRaw[i];
+//   //   teamFiltered = teamRaw;
+//   //   teamList.push(teamFiltered);
+//   // }
+//   return teamListData.teamList;
+// };
 
 export const getTeamPersonsList = (teamListData, teamId) => {
   console.log('TeamsQueryProcessing, getTeamPersonsList teamId:', teamId);

--- a/src/js/react-query/WeConnectQuery.js
+++ b/src/js/react-query/WeConnectQuery.js
@@ -25,11 +25,11 @@ const weConnectQueryFn = async (queryKey, params, isGet) => {
 };
 
 const useFetchData = (queryKey, fetchParams, isGet) => {
-  httpLog('useFetchData queryKey: ', queryKey, '  fetchParams: ', fetchParams);
+  httpLog('useFetchData queryKey, fetchParams before fetch: ', queryKey, '  fetchParams: ', fetchParams);
   const { data, isSuccess, isFetching, isStale, refetch, error } = useQuery({
     queryKey,
     queryFn: () => weConnectQueryFn(queryKey, fetchParams, isGet),
-    networkMode: 'always',  // TODO: Investigate now ... We can back this off once we achieve MVP version 1
+    // networkMode: 'always',  // <-- This is not a solution, it just covers up some problem in our code, while disabling the biggest benefit of ReactQueries.
   });
   if (error) {
     console.log(`An error occurred with ${queryKey}: ${error.message}`);

--- a/src/js/react-query/mutations.jsx
+++ b/src/js/react-query/mutations.jsx
@@ -61,7 +61,8 @@ const useTaskDefinitionSaveMutation = () => {
   return useMutation({
     mutationFn: (params) => weConnectQueryFn('task-definition-save', params, METHOD.GET),
     onError: (error) => console.log('error in useTaskDefinitionSaveMutation: ', error),
-    onSuccess: () => queryClient.invalidateQueries('task-status-list-retrieve'),
+    // onSuccess: () => queryClient.invalidateQueries('task-status-list-retrieve'),
+    onSuccess: () => queryClient.invalidateQueries('task-group-retrieve'),
   });
 };
 

--- a/src/js/stores/AppObservableStore.js
+++ b/src/js/stores/AppObservableStore.js
@@ -1,920 +1,920 @@
-import { Subject } from 'rxjs';
-// import VoterActions from '../actions/VoterActions'; // eslint-disable-line import/no-cycle
-import stringContains from '../common/utils/stringContains';
-import webAppConfig from '../config';
-// import VoterStore from './VoterStore'; // eslint-disable-line import/no-cycle
-import { dumpObjProps } from '../utils/appleSiliconUtils';
-import $ajax from '../utils/service';
-
-const subject = new Subject();
-
-function isCordovaLocal () {
-  const { cordova } = window;
-  return cordova !== undefined;
-}
-
-export const messageService = {
-  sendMessage: (message) => subject.next({ text: message }),
-  clearMessages: () => subject.next(),
-  getMessage: () => subject.asObservable(),
-};
-
-const nonFluxState = {
-  activityTidbitWeVoteIdForDrawer: '',
-  addPersonDrawerOpen: false,
-  addPersonDrawerTeamId: -1, // Team ID used when adding a new person
-  addTeamDrawerOpen: false,
-  blockChallengeRedirectOnSignIn: false, // When signing in from the header, don't mark a challenge as supported
-  challengeParticipantNameWithHighestRankByChallengeWeVoteId: {}, // Key is challengeWeVoteId, value is name for voter with the highest rank for that challenge
-  challengeParticipantRankOfVoterByChallengeWeVoteId: {}, // Key is challengeWeVoteId, value is rank of voter for that challenge
-  chosenDomainTypeIsCampaign: false,
-  chosenGoogleAnalyticsTrackingID: false,
-  chosenPreventSharingOpinions: false,
-  chosenReadyIntroductionText: '',
-  chosenReadyIntroductionTitle: '',
-  chosenSiteLogoUrl: '',
-  chosenWebsiteName: '',
-  currentPathname: '',
-  editPersonDrawerOpen: false,
-  editPersonDrawerPersonId: -1,
-  editPersonDrawerTeamId: -1,
-  emailPersonalChanged: false,
-  emailPersonalToBeSaved: '',
-  firstNameChanged: false,
-  firstNameToBeSaved: '',
-  getStartedMode: '',
-  getVoterGuideSettingsDashboardEditMode: '',
-  googleAnalyticsEnabled: false,
-  googleAnalyticsPending: false,
-  hideOrganizationModalBallotItemInfo: false,
-  hideOrganizationModalPositions: false,
-  hideWeVoteLogo: false,
-  hostname: '',
-  lastNameChanged: false,
-  lastNameToBeSaved: '',
-  observableUpdateCounter: 0,
-  openReplayEnabled: false,
-  openReplayPending: false,
-  openReplayTracker: undefined,
-  openReplayVoterIsSignedIn: '',
-  openReplayVoterWeVoteId: '',
-  pendingSnackMessage: '',
-  pendingSnackSeverity: '',
-  recommendedCampaignListFirstRetrieveInitiated: false,
-  scrolledDown: false,
-  scrolledDownDrawer: false,
-  setUpAccountBackLinkPath: '',
-  setUpAccountEntryPath: '',
-  whatAndHowMuchToShare: '',
-  sharedItemCode: '',
-  showActivityTidbitDrawer: false,
-  showAdviserIntroModal: false,
-  showAskFriendsModal: false,
-  showChooseOrOpposeIntroModal: false,
-  showCompleteYourProfileModal: false,
-  showEditAddressButton: false,
-  showElectionsWithOrganizationVoterGuidesModal: false,
-  showHeader: 0,
-  showHowItWorksModal: false,
-  showNewVoterGuideModal: false,
-  showOrganizationModal: false,
-  showPaidAccountUpgradeModal: false,
-  showPersonalizedScoreIntroModal: false,
-  showPositionDrawer: false,
-  showSelectBallotModal: false,
-  showSelectBallotModalEditAddress: false,
-  showShareModal: false,
-  showSharedItemModal: false,
-  showSignInModal: false,
-  showTwitterLandingPage: false,
-  showVoterPlanModal: false,
-  signInStateChanged: false,
-  siteConfigurationHasBeenRetrieved: false,
-  siteOwnerOrganizationWeVoteId: '',
-  storeSignInStartFullUrl: false,
-  teamNameChanged: false,
-  teamNameToBeSaved: '',
-  viewingOrganizationVoterGuide: false,
-  voterBallotItemsRetrieveHasBeenCalled: false,
-  voterExternalIdHasBeenSavedOnce: {}, // Dict with externalVoterId and membershipOrganizationWeVoteId as keys, and true/false as value
-  voterFirstRetrieveInitiated: false,
-};
-
-
-export default {
-  blockChallengeRedirectOnSignIn () {
-    return nonFluxState.blockChallengeRedirectOnSignIn;
-  },
-
-  getActivityTidbitWeVoteIdForDrawer () {
-    return nonFluxState.activityTidbitWeVoteIdForDrawer;
-  },
-
-  getChallengeParticipantNameWithHighestRankByChallengeWeVoteId (challengeWeVoteId) {
-    if (challengeWeVoteId && challengeWeVoteId in nonFluxState.challengeParticipantNameWithHighestRankByChallengeWeVoteId) {
-      return nonFluxState.challengeParticipantNameWithHighestRankByChallengeWeVoteId[challengeWeVoteId];
-    } else {
-      return '';
-    }
-  },
-
-  getChallengeParticipantRankOfVoterByChallengeWeVoteId (challengeWeVoteId) {
-    if (challengeWeVoteId && challengeWeVoteId in nonFluxState.challengeParticipantRankOfVoterByChallengeWeVoteId) {
-      return nonFluxState.challengeParticipantRankOfVoterByChallengeWeVoteId[challengeWeVoteId];
-    } else {
-      return 0;
-    }
-  },
-
-  getChosenAboutOrganizationExternalUrl () {
-    return nonFluxState.chosenAboutOrganizationExternalUrl;
-  },
-
-  getChosenDomainTypeIsCampaign () {
-    return nonFluxState.chosenDomainTypeIsCampaign;
-  },
-
-  getChosenDomainTypeIsChallenge () {
-    return false;
-  },
-
-  getChosenGoogleAnalyticsTrackingID () {
-    return nonFluxState.chosenGoogleAnalyticsTrackingID;
-  },
-
-  getChosenPreventSharingOpinions () {
-    return nonFluxState.chosenPreventSharingOpinions;
-  },
-
-  getChosenReadyIntroductionText () {
-    return nonFluxState.chosenReadyIntroductionText;
-  },
-
-  getChosenReadyIntroductionTitle () {
-    return nonFluxState.chosenReadyIntroductionTitle;
-  },
-
-  getChosenSiteLogoUrl () {
-    return nonFluxState.chosenSiteLogoUrl;
-  },
-
-  getChosenWebsiteName () {
-    return nonFluxState.chosenWebsiteName || 'WeVote.US'; // Used to be campaigns.WeVote.US on campaigns site
-  },
-
-  getCurrentPathname () {
-    return nonFluxState.currentPathname;
-  },
-
-  getGlobalVariableState (globalVariableName) {
-    return nonFluxState[globalVariableName];
-  },
-
-  getGoogleAnalyticsEnabled () {
-    return nonFluxState.googleAnalyticsEnabled;
-  },
-
-  getGoogleAnalyticsPending () {
-    return nonFluxState.googleAnalyticsPending;
-  },
-
-  getOpenReplayEnabled () {
-    return nonFluxState.openReplayEnabled;
-  },
-
-  getOpenReplayPending () {
-    return nonFluxState.openReplayPending;
-  },
-
-  getOpenReplayStateCode () {
-    return nonFluxState.stateCode;
-  },
-
-  getOpenReplayStateCodeFromIpAddress () {
-    return nonFluxState.stateCodeFromIpAddress;
-  },
-
-  getOpenReplayTracker () {
-    return nonFluxState.openReplayTracker;
-  },
-
-  getOpenReplayVoterIsSignedIn () {
-    return nonFluxState.openReplayVoterIsSignedIn;
-  },
-
-  getOpenReplayVoterWeVoteId () {
-    return nonFluxState.openReplayVoterWeVoteId;
-  },
-
-  getHideWeVoteLogo () {
-    return nonFluxState.hideWeVoteLogo;
-  },
-
-  getHostname () {
-    return nonFluxState.hostname || '';
-  },
-
-  getPendingSnackMessage () {
-    return nonFluxState.pendingSnackMessage;
-  },
-
-  getPendingSnackSeverity () {
-    return nonFluxState.pendingSnackSeverity;
-  },
-
-  getScrolledDown () {
-    return nonFluxState.scrolledDown;
-  },
-
-  getScrolledDownDrawer () {
-    return nonFluxState.scrolledDownDrawer;
-  },
-
-  getSetUpAccountBackLinkPath () {
-    return nonFluxState.setUpAccountBackLinkPath;
-  },
-
-  getSetUpAccountEntryPath () {
-    return nonFluxState.setUpAccountEntryPath;
-  },
-
-  getSharedItemCode () {
-    return nonFluxState.sharedItemCode;
-  },
-
-  getShareModalStep () {
-    // console.log('AppObservableStore shareModalStep:', nonFluxState.shareModalStep);
-    return nonFluxState.shareModalStep;
-  },
-
-  getWeVoteRootURL () {
-    const { location: { hostname, origin } } = window;
-    if (hostname === 'localhost' || hostname === 'quality.wevote.us' || hostname === 'wevotedeveloper.com') {
-      return origin; // ex/ https://localhost:3000
-    } else {
-      return 'https://wevote.us';
-    }
-  },
-
-  getWhatAndHowMuchToShare () {
-    // console.log('getWhatAndHowMuchToShare:', nonFluxState.whatAndHowMuchToShare);
-    return nonFluxState.whatAndHowMuchToShare;
-  },
-
-  getShowTwitterLandingPage () {
-    // console.log('AppObservableStore getShowTwitterLandingPage:', nonFluxState.showTwitterLandingPage);
-    return nonFluxState.showTwitterLandingPage;
-  },
-
-  getSignInStateChanged () {
-    return nonFluxState.signInStateChanged;
-  },
-
-  getSiteOwnerOrganizationWeVoteId () {
-    return nonFluxState.siteOwnerOrganizationWeVoteId;
-  },
-
-  getStartedMode () {
-    return nonFluxState.getStartedMode;
-  },
-
-  getVoterGuideSettingsDashboardEditMode () {
-    return nonFluxState.getVoterGuideSettingsDashboardEditMode;
-  },
-
-  hideOrganizationModalBallotItemInfo () {
-    return nonFluxState.hideOrganizationModalBallotItemInfo;
-  },
-
-  hideOrganizationModalPositions () {
-    return nonFluxState.hideOrganizationModalPositions;
-  },
-
-  inPrivateLabelMode () {
-    return Boolean(nonFluxState.chosenSiteLogoUrl || false);
-  },
-
-  isSnackMessagePending () {
-    return nonFluxState.pendingSnackMessage && nonFluxState.pendingSnackMessage.length > 0;
-  },
-
-  isOnWeVoteRootUrl () {
-    // console.log('AppObservableStore nonFluxState.onWeVoteRootUrl: ', nonFluxState.onWeVoteRootUrl,
-    //   ', isOnWeVoteRootUrl weVoteURL: ', weVoteURL,
-    //   ', isCordovaLocal(): ', isCordovaLocal());
-
-    const { location: { href: hrefValue } } = window;
-    // console.log('AppObservableStore hrefValue: ', hrefValue);
-    const hrefValueLowerCase = (hrefValue) ? hrefValue.toLowerCase() : '';
-    return (nonFluxState.onWeVoteRootUrl || false) ||
-      isCordovaLocal() ||
-      stringContains('quality.wevote.us:', hrefValueLowerCase) ||
-      stringContains('www.wevote.us:', hrefValueLowerCase) ||
-      stringContains('//wevote.us:', hrefValueLowerCase) ||
-      stringContains('wevote.org:', hrefValueLowerCase) ||
-      stringContains('localhost:', hrefValueLowerCase) ||
-      stringContains('wevotedeveloper.com:', hrefValueLowerCase) ||
-      stringContains('ngrok.io', hrefValueLowerCase) ||
-      stringContains('ngrok-free.app', hrefValueLowerCase);
-  },
-
-  isOnFacebookJsSdkHostDomainList () {
-    const { hostname } = window.location;
-    const hostnameLowerCase = (hostname) ? hostname.toLowerCase() : '';
-    const hostnameFiltered = hostnameLowerCase.replace('www.', '');
-    // console.log('----------------------', hostname);
-    return hostnameFiltered === 'wevote.us' ||
-      hostnameFiltered === 'quality.wevote.us' ||
-      hostnameFiltered === 'localhost' ||
-      hostnameFiltered === 'wevotedeveloper.com' ||
-      isCordovaLocal() ||
-      window.location.href.includes('ngrok');
-  },
-
-  isOnWeVotePartnerSubdomainUrl () {
-    // console.log('AppObservableStore isOnWeVotePartnerSubdomainUrl: ', nonFluxState.onWeVotePartnerSubdomainUrl);
-    return nonFluxState.onWeVotePartnerSubdomainUrl;
-  },
-
-  isOnPartnerUrl () {
-    // console.log('AppObservableStore onWeVotePartnerSubdomainUrl: ', nonFluxState.onWeVotePartnerSubdomainUrl, ', onChosenFullDomainUrl:', nonFluxState.onChosenFullDomainUrl);
-    return nonFluxState.onWeVotePartnerSubdomainUrl || nonFluxState.onChosenFullDomainUrl;
-  },
-
-  isVoterAdminForThisUrl (linkedOrganizationWeVoteId) {
-    // const linkedOrganizationWeVoteId = VoterStore.getLinkedOrganizationWeVoteId();
-    return nonFluxState.siteOwnerOrganizationWeVoteId === linkedOrganizationWeVoteId;
-  },
-
-  isOnFacebookSupportedDomainUrl () {
-    return nonFluxState.onFacebookSupportedDomainUrl;
-  },
-
-  isOnChosenFullDomainUrl () {
-    return nonFluxState.onChosenFullDomainUrl;
-  },
-
-  recommendedCampaignListFirstRetrieveInitiated () {
-    return nonFluxState.recommendedCampaignListFirstRetrieveInitiated;
-  },
-
-  incrementObservableUpdateCounter () {
-    nonFluxState.observableUpdateCounter += 1;
-    messageService.sendMessage('state incremented ObservableUpdateCounter');
-  },
-
-  setActivityTidbitWeVoteIdForDrawer (activityTidbitWeVoteId) {
-    nonFluxState.activityTidbitWeVoteIdForDrawer = activityTidbitWeVoteId;
-    messageService.sendMessage('state updated activityTidbitWeVoteIdForDrawer');
-  },
-
-  setActivityTidbitWeVoteIdForDrawerAndOpen (setActivityTidbitWeVoteIdForDrawerAndOpen) {
-    nonFluxState.activityTidbitWeVoteIdForDrawerAndOpen = setActivityTidbitWeVoteIdForDrawerAndOpen;
-    messageService.sendMessage('state updated activityTidbitWeVoteIdForDrawerAndOpen');
-  },
-
-  setBlockChallengeRedirectOnSignIn (value) {
-    nonFluxState.blockChallengeRedirectOnSignIn = value;
-    messageService.sendMessage('state updated blockChallengeRedirectOnSignIn');
-  },
-
-  setChallengeParticipantRankOfVoter (challengeWeVoteId, rank) {
-    // console.log('setChallengeParticipantRankOfVoter: ', challengeWeVoteId, ', rank: ', rank);
-    nonFluxState.challengeParticipantRankOfVoterByChallengeWeVoteId[challengeWeVoteId] = rank;
-    messageService.sendMessage('state updated challengeParticipantRankOfVoterByChallengeWeVoteId');
-  },
-
-  setChallengeParticipantNameWithHighestRank (challengeWeVoteId, voterName) {
-    // console.log('setChallengeParticipantNameWithHighestRank: ', challengeWeVoteId, ', voterName: ', voterName);
-    nonFluxState.challengeParticipantNameWithHighestRankByChallengeWeVoteId[challengeWeVoteId] = voterName;
-    messageService.sendMessage('state updated challengeParticipantNameWithHighestRankByChallengeWeVoteId');
-  },
-
-  setCurrentPathname (currentPathname) {
-    nonFluxState.currentPathname = currentPathname;
-    messageService.sendMessage('state updated currentPathname');
-  },
-
-  setEvaluateHeaderDisplay () {
-    // Force the Header to evaluate whether it should display
-    nonFluxState.showHeader = Date.now();
-    messageService.sendMessage('state updated showHeader');
-  },
-
-  setGetStartedMode (getStartedMode) {
-    nonFluxState.getStartedMode = getStartedMode;
-    messageService.sendMessage('state updated getStartedMode');
-  },
-
-  setGlobalVariableState (globalVariableName, newState) {
-    nonFluxState[globalVariableName] = newState;
-    messageService.sendMessage(`state updated ${globalVariableName}`);
-  },
-
-  setGlobalVariableStateInBulk (globalVariableStateDict) {
-    const keys = Object.keys(globalVariableStateDict);
-    const values = Object.values(globalVariableStateDict);
-    for (let i = 0; i < keys.length; i++) {
-      nonFluxState[keys[i]] = values[i];
-    }
-    messageService.sendMessage('state updated multiple global variables');
-  },
-
-  setHideOrganizationModalBallotItemInfo (hide) {
-    nonFluxState.hideOrganizationModalBallotItemInfo = hide;
-    messageService.sendMessage('state updated hideOrganizationModalBallotItemInfo');
-  },
-
-  setHideOrganizationModalPositions (hide) {
-    nonFluxState.hideOrganizationModalPositions = hide;
-    messageService.sendMessage('state updated hideOrganizationModalPositions');
-  },
-
-  setGoogleAnalyticsEnabled (enabled) {
-    nonFluxState.googleAnalyticsEnabled = enabled;
-    messageService.sendMessage('state updated googleAnalyticsEnabled');
-  },
-
-  setGoogleAnalyticsPending (enabled) {
-    nonFluxState.googleAnalyticsPending = enabled;
-    messageService.sendMessage('state updated googleAnalyticsPending');
-  },
-
-  setOpenReplayEnabled (enabled) {
-    nonFluxState.openReplayEnabled = enabled;
-    messageService.sendMessage('state updated openReplayEnabled');
-  },
-
-  setOpenReplayPending (enabled) {
-    nonFluxState.openReplayPending = enabled;
-    messageService.sendMessage('state updated openReplayPending');
-  },
-
-  setOpenReplayStateCode (stateCode) {
-    nonFluxState.stateCode = stateCode;
-    messageService.sendMessage('state updated stateCode');
-  },
-
-  setOpenReplayStateCodeFromIpAddress (stateCodeFromIpAddress) {
-    nonFluxState.stateCodeFromIpAddress = stateCodeFromIpAddress;
-    messageService.sendMessage('state updated stateCodeFromIpAddress');
-  },
-
-  setOpenReplayTracker (tracker) {
-    nonFluxState.openReplayTracker = tracker;
-    messageService.sendMessage('state updated openReplayTracker');
-  },
-
-  setOpenReplayVoterIsSignedIn (value) {
-    nonFluxState.openReplayVoterIsSignedIn = value;
-    messageService.sendMessage('state updated openReplayVoterIsSignedIn');
-  },
-
-  setOpenReplayVoterWeVoteId (value) {
-    nonFluxState.openReplayVoterWeVoteId = value;
-    messageService.sendMessage('state updated openReplayVoterWeVoteId');
-  },
-
-  setPendingSnackMessage (message, severity) {
-    nonFluxState.pendingSnackMessage = message;
-    nonFluxState.pendingSnackSeverity = severity;
-  },
-
-  setRecommendedCampaignListFirstRetrieveInitiated (value) {
-    nonFluxState.recommendedCampaignListFirstRetrieveInitiated = value;
-    messageService.sendMessage('state updated recommendedCampaignListFirstRetrieveInitiated');
-  },
-
-  setScrolled (scrolledDown) {
-    nonFluxState.scrolledDown = scrolledDown;
-    messageService.sendMessage('state updated scrolledDown');
-  },
-
-  setScrolledDownDrawer (scrolledDown) {
-    nonFluxState.scrolledDownDrawer = scrolledDown;
-    messageService.sendMessage('state updated scrolledDownDrawer');
-  },
-
-  setSetUpAccountBackLinkPath (backLinkPath) {
-    // console.log('setSetUpAccountBackLinkPath, step:', step);
-    nonFluxState.setUpAccountBackLinkPath = backLinkPath;
-    messageService.sendMessage('state updated setUpAccountBackLinkPath');
-  },
-
-  setSetUpAccountEntryPath (entryPath) {
-    // console.log('setSetUpAccountEntryPath, step:', step);
-    nonFluxState.setUpAccountEntryPath = entryPath;
-    messageService.sendMessage('state updated setSetUpAccountEntryPath');
-  },
-
-  setShowActivityTidbitDrawer (show) {
-    nonFluxState.showActivityTidbitDrawer = show;
-    messageService.sendMessage('state updated showActivityTidbitDrawer');
-  },
-
-  setShowAdviserIntroModal (show) {
-    nonFluxState.showAdviserIntroModal = show;
-    messageService.sendMessage('state updated showAdviserIntroModal');
-  },
-
-  setShowAskFriendsModal (show) {
-    nonFluxState.showAskFriendsModal = show;
-    messageService.sendMessage('state updated showAskFriendsModal');
-  },
-
-  setShowChallengeThanksForJoining (show) {
-    nonFluxState.showChallengeThanksForJoining = show;
-    messageService.sendMessage('state updated showChallengeThanksForJoining');
-  },
-
-  setShowChooseOrOpposeIntroModal (show, ballotItemType = 'CANDIDATE') {
-    nonFluxState.showChooseOrOpposeIntroModal = show;
-    nonFluxState.showChooseOrOpposeIntroModalBallotItemType = ballotItemType;
-    messageService.sendMessage('state updated showChooseOrOpposeIntroModal');
-  },
-
-  setShowCompleteYourProfileModal (show) {
-    nonFluxState.showCompleteYourProfileModal = show;
-    messageService.sendMessage('state updated showCompleteYourProfileModal');
-  },
-
-  setShowEditAddressButton (show) {
-    nonFluxState.showEditAddressButton = show;
-    messageService.sendMessage('state updated showEditAddressButton');
-  },
-
-  setShowElectionsWithOrganizationVoterGuidesModal (show) {
-    nonFluxState.showElectionsWithOrganizationVoterGuidesModal = show;
-    messageService.sendMessage('state updated showElectionsWithOrganizationVoterGuidesModal');
-  },
-
-  setShowFirstPositionIntroModal (show) {
-    nonFluxState.showFirstPositionIntroModal = show;
-    messageService.sendMessage('state updated showFirstPositionIntroModal');
-  },
-
-  setShowHowItWorksModal (show) {
-    // The chosenPaidAccount values are: free, professional, enterprise
-    nonFluxState.showHowItWorksModal = show;
-    messageService.sendMessage('state updated showHowItWorksModal');
-  },
-
-  setShowImageUploadModal (show) {
-    // console.log('Setting image upload modal to open!');
-    nonFluxState.showImageUploadModal = show;
-    messageService.sendMessage('state updated showImageUploadModal');
-  },
-
-  setShowNewVoterGuideModal (show) {
-    nonFluxState.showNewVoterGuideModal = show;
-    messageService.sendMessage('state updated showNewVoterGuideModal');
-  },
-
-  setShowOrganizationModal (show) {
-    // console.log("Setting organizationModal to ", show);
-    nonFluxState.showOrganizationModal = show;
-    messageService.sendMessage('state updated showOrganizationModal');
-  },
-
-  setShowPaidAccountUpgradeModal (chosenPaidAccount) {
-    // The chosenPaidAccount values are: free, professional, enterprise
-    nonFluxState.showPaidAccountUpgradeModal = chosenPaidAccount;
-    messageService.sendMessage('state updated showPaidAccountUpgradeModal');
-  },
-
-  setShowPersonalizedScoreIntroModal (show) {
-    nonFluxState.showPersonalizedScoreIntroModal = show;
-    messageService.sendMessage('state updated showPersonalizedScoreIntroModal');
-  },
-
-  setShowPositionDrawer (show) {
-    nonFluxState.showPositionDrawer = show;
-    messageService.sendMessage('state updated showPositionDrawer');
-  },
-
-  setShowSelectBallotModal (showSelectBallotModal, showSelectBallotModalEditAddress = false) {
-    nonFluxState.showSelectBallotModalEditAddress = showSelectBallotModalEditAddress;
-    nonFluxState.showSelectBallotModal = showSelectBallotModal;
-    // console.log('setShowSelectBallotModal showSelectBallotModalEditAddress:', showSelectBallotModalEditAddress);
-    messageService.sendMessage('state updated showSelectBallotModal, showSelectBallotModalEditAddress');
-  },
-
-  setShowSelectBallotModalOnly (showSelectBallotModal) {
-    nonFluxState.showSelectBallotModal = showSelectBallotModal;
-    messageService.sendMessage('state updated showSelectBallotModalOnly');
-  },
-
-  setShowShareModal (show) {
-    // The chosenPaidAccount values are: free, professional, enterprise
-    nonFluxState.showShareModal = show;
-    messageService.sendMessage('state updated showShareModal');
-  },
-
-  setShowSharedItemModal (sharedItemCode) {
-    nonFluxState.sharedItemCode = sharedItemCode;
-    nonFluxState.showSharedItemModal = Boolean(sharedItemCode);
-    messageService.sendMessage('state updated showSharedItemModal');
-  },
-
-  setShowSignInModal (show) {
-    nonFluxState.showSignInModal = show;
-    messageService.sendMessage('state updated showSignInModal');
-  },
-
-  setShowTwitterLandingPage (show) {
-    nonFluxState.showTwitterLandingPage = show;
-    messageService.sendMessage('state updated showTwitterLandingPage');
-  },
-
-  setShowValuesIntroModal (show) {
-    nonFluxState.showValuesIntroModal = show;
-    messageService.sendMessage('state updated showValuesIntroModal');
-  },
-
-  setShowVoterPlanModal (show) {
-    // The chosenPaidAccount values are: free, professional, enterprise
-    nonFluxState.showVoterPlanModal = show;
-    messageService.sendMessage('state updated showVoterPlanModal');
-  },
-
-  setSignInStateChanged (signin) {
-    nonFluxState.signInStateChanged = signin;
-    messageService.sendMessage('state updated signInStateChanged');
-  },
-
-  setSignInStartFullUrl () {
-    nonFluxState.storeSignInStartFullUrl = true;
-    messageService.sendMessage('state updated storeSignInStartFullUrl');
-  },
-
-  setStoreSignInStartFullUrl () {
-    nonFluxState.storeSignInStartFullUrl = true;
-    messageService.sendMessage('state updated storeSignInStartFullUrl');
-  },
-
-  setViewingOrganizationVoterGuide (isViewing) {
-    nonFluxState.viewingOrganizationVoterGuide = isViewing;
-    messageService.sendMessage('state updated viewingOrganizationVoterGuide');
-  },
-
-  setVoterGuideSettingsDashboardEditMode (getVoterGuideSettingsDashboardEditMode) {
-    nonFluxState.getVoterGuideSettingsDashboardEditMode = getVoterGuideSettingsDashboardEditMode;
-    messageService.sendMessage('state updated getVoterGuideSettingsDashboardEditMode');
-  },
-
-  setVoterBallotItemsRetrieveHasBeenCalled (voterBallotItemsRetrieveHasBeenCalled) {
-    nonFluxState.voterBallotItemsRetrieveHasBeenCalled = voterBallotItemsRetrieveHasBeenCalled;
-    messageService.sendMessage('state updated voterBallotItemsRetrieveHasBeenCalled');
-  },
-
-  setVoterFirstRetrieveInitiated (voterFirstRetrieveInitiated) {
-    nonFluxState.voterFirstRetrieveInitiated = voterFirstRetrieveInitiated;
-    messageService.sendMessage('state updated voterFirstRetrieveInitiated');
-  },
-
-  setWhatAndHowMuchToShare (step) {
-    // console.log('setWhatAndHowMuchToShare, step:', step);
-    nonFluxState.whatAndHowMuchToShare = step;
-    messageService.sendMessage('state updated whatAndHowMuchToShare');
-  },
-
-  showActivityTidbitDrawer () {
-    return nonFluxState.showActivityTidbitDrawer;
-  },
-
-  showAdviserIntroModal () {
-    return nonFluxState.showAdviserIntroModal;
-  },
-
-  showAskFriendsModal () {
-    return nonFluxState.showAskFriendsModal;
-  },
-
-  showChallengeThanksForJoining () {
-    return nonFluxState.showChallengeThanksForJoining;
-  },
-
-  showChooseOrOpposeIntroModal () {
-    return nonFluxState.showChooseOrOpposeIntroModal;
-  },
-
-  showCompleteYourProfileModal () {
-    return nonFluxState.showCompleteYourProfileModal;
-  },
-
-  // showEditAddressButton () {
-  //   return nonFluxState.showEditAddressButton;
-  // },
-
-  showElectionsWithOrganizationVoterGuidesModal () {
-    return nonFluxState.showElectionsWithOrganizationVoterGuidesModal;
-  },
-
-  showFirstPositionIntroModal () {
-    return nonFluxState.showFirstPositionIntroModal;
-  },
-
-  showHowItWorksModal () {
-    return nonFluxState.showHowItWorksModal;
-  },
-
-  showingOneCompleteYourProfileModal () {
-    return nonFluxState.showAdviserIntroModal ||
-      nonFluxState.showFirstPositionIntroModal ||
-      nonFluxState.showHowItWorksModal ||
-      nonFluxState.showPersonalizedScoreIntroModal ||
-      nonFluxState.showSelectBallotModal ||
-      nonFluxState.showSharedItemModal ||
-      nonFluxState.showValuesIntroModal;
-  },
-
-  showNewVoterGuideModal () {
-    return nonFluxState.showNewVoterGuideModal;
-  },
-
-  showPaidAccountUpgradeModal () {
-    // The chosenPaidAccount values are: free, professional, enterprise
-    return nonFluxState.showPaidAccountUpgradeModal;
-  },
-
-  showPersonalizedScoreIntroModal () {
-    return nonFluxState.showPersonalizedScoreIntroModal;
-  },
-
-  showPositionDrawer () {
-    return nonFluxState.showPositionDrawer;
-  },
-
-  showShareModal () {
-    return nonFluxState.showShareModal;
-  },
-
-  showSharedItemModal () {
-    return nonFluxState.showSharedItemModal;
-  },
-
-  showSelectBallotModal () {
-    return nonFluxState.showSelectBallotModal;
-  },
-
-  showSelectBallotModalEditAddress () {
-    return nonFluxState.showSelectBallotModalEditAddress;
-  },
-
-  showSignInModal () {
-    return nonFluxState.showSignInModal;
-  },
-
-  showOrganizationModal () {
-    return nonFluxState.showOrganizationModal;
-  },
-
-  showValuesIntroModal () {
-    return nonFluxState.showValuesIntroModal;
-  },
-
-  showImageUploadModal () {
-    return nonFluxState.showImageUploadModal;
-  },
-
-  showVoterPlanModal () {
-    return nonFluxState.showVoterPlanModal;
-  },
-
-  siteConfigurationHasBeenRetrieved () {
-    // let { hostname } = window.location;
-    // hostname = hostname || '';
-    // if (hostname === 'campaigns.wevote.us') {
-    //   // Bypass for default site
-    //   return true;
-    // } else {
-    //   return nonFluxState.siteConfigurationHasBeenRetrieved;
-    // }
-    return nonFluxState.siteConfigurationHasBeenRetrieved;
-  },
-
-  siteConfigurationRetrieve (hostname, externalVoterId = '', refresh_string = '') {
-    $ajax({
-      endpoint: 'siteConfigurationRetrieve',
-      data: { hostname, refresh_string },
-      success: (res) => {
-        // console.log('AppObservableStore siteConfigurationRetrieve success, res:', res);
-        const {
-          status: apiStatus,
-          success: apiSuccess,
-          hostname: hostFromApi,
-          organization_we_vote_id: siteOwnerOrganizationWeVoteId,
-          chosen_about_organization_external_url: chosenAboutOrganizationExternalUrl,
-          chosen_domain_type_is_campaign: chosenDomainTypeIsCampaign,
-          chosen_google_analytics_tracking_id: chosenGoogleAnalyticsTrackingID,
-          chosen_hide_we_vote_logo: hideWeVoteLogo,
-          chosen_logo_url_https: chosenSiteLogoUrl,
-          chosen_prevent_sharing_opinions: chosenPreventSharingOpinions,
-          chosen_ready_introduction_text: chosenReadyIntroductionText,
-          chosen_ready_introduction_title: chosenReadyIntroductionTitle,
-          chosen_website_name: chosenWebsiteName,
-        } = res;
-        let newHostname = hostFromApi ? hostFromApi.replace('www.', '') : hostname.replace('www.', '');
-        if (apiSuccess) {
-          let onWeVoteRootUrl = false;
-          let onWeVotePartnerSubdomainUrl = false;
-          let onFacebookSupportedDomainUrl = false;
-          let onChosenFullDomainUrl = false;
-
-          if (isCordovaLocal()) {
-            newHostname = webAppConfig.HOSTNAME;
-          }
-
-          onWeVoteRootUrl = this.isOnWeVoteRootUrl();
-          // console.log('AppObservableStore siteConfigurationRetrieve hostname, newHostname:', hostname, newHostname, ', onWeVoteRootUrl:', onWeVoteRootUrl);
-          if (!onWeVoteRootUrl && stringContains('wevote.us', newHostname)) {
-            onWeVotePartnerSubdomainUrl = true;
-          } else if (!onWeVoteRootUrl) {
-            onChosenFullDomainUrl = true;
-          }
-          onFacebookSupportedDomainUrl = this.isOnFacebookJsSdkHostDomainList();
-          // console.log('AppObservableStore siteConfigurationRetrieve onFacebookSupportedDomainUrl:', onFacebookSupportedDomainUrl);
-          // console.log('AppObservableStore externalVoterId:', externalVoterId, ', siteOwnerOrganizationWeVoteId:', siteOwnerOrganizationWeVoteId);
-          const { voterExternalIdHasBeenSavedOnce } = nonFluxState;
-          if (externalVoterId && siteOwnerOrganizationWeVoteId) {
-            if (!this.voterExternalIdHasBeenSavedOnce(externalVoterId, siteOwnerOrganizationWeVoteId)) {
-              // console.log('voterExternalIdHasBeenSavedOnce has NOT been saved before.');
-              // Hack 1/14/25 VoterActions.voterExternalIdSave(externalVoterId, siteOwnerOrganizationWeVoteId);
-              if (!voterExternalIdHasBeenSavedOnce[externalVoterId]) {
-                voterExternalIdHasBeenSavedOnce[externalVoterId] = {};
-              }
-              voterExternalIdHasBeenSavedOnce[externalVoterId][siteOwnerOrganizationWeVoteId] = true;
-              // AnalyticsActions.saveActionBallotVisit(VoterStore.electionId());
-            } else {
-              // console.log('voterExternalIdHasBeenSavedOnce has been saved before.');
-            }
-          }
-          nonFluxState.apiStatus = apiStatus;
-          nonFluxState.apiSuccess = apiSuccess;
-          nonFluxState.chosenAboutOrganizationExternalUrl = chosenAboutOrganizationExternalUrl;
-          nonFluxState.chosenDomainTypeIsCampaign = chosenDomainTypeIsCampaign;
-          nonFluxState.chosen_google_analytics_tracking_id = chosenGoogleAnalyticsTrackingID;
-          nonFluxState.chosenPreventSharingOpinions = chosenPreventSharingOpinions;
-          nonFluxState.chosenReadyIntroductionText = chosenReadyIntroductionText;
-          nonFluxState.chosenReadyIntroductionTitle = chosenReadyIntroductionTitle;
-          nonFluxState.chosenSiteLogoUrl = chosenSiteLogoUrl;
-          nonFluxState.chosenWebsiteName = chosenWebsiteName;
-          nonFluxState.hideWeVoteLogo = hideWeVoteLogo;
-          nonFluxState.hostname = newHostname;
-          nonFluxState.onChosenFullDomainUrl = onChosenFullDomainUrl;
-          nonFluxState.onFacebookSupportedDomainUrl = onFacebookSupportedDomainUrl;
-          nonFluxState.onWeVotePartnerSubdomainUrl = onWeVotePartnerSubdomainUrl;
-          nonFluxState.onWeVoteRootUrl = onWeVoteRootUrl;
-          nonFluxState.siteConfigurationHasBeenRetrieved = true;
-          nonFluxState.siteOwnerOrganizationWeVoteId = siteOwnerOrganizationWeVoteId;
-          nonFluxState.voterExternalIdHasBeenSavedOnce = voterExternalIdHasBeenSavedOnce;
-          messageService.sendMessage('state updated for siteConfigurationRetrieve');
-        }
-      },
-
-      error: (res) => {
-        console.error('AppObservableStore error: ', res);
-        dumpObjProps('AppObservableStore error', res);
-      },
-    });
-  },
-
-  storeSignInStartFullUrl () {
-    return nonFluxState.storeSignInStartFullUrl;
-  },
-
-  unsetStoreSignInStartFullUrl () {
-    nonFluxState.unsetStoreSignInStartFullUrl = false;
-    messageService.sendMessage('state updated unsetStoreSignInStartFullUrl');
-  },
-
-  voterBallotItemsRetrieveHasBeenCalled () {
-    return nonFluxState.voterBallotItemsRetrieveHasBeenCalled;
-  },
-
-  voterCanStartCampaignXForThisPrivateLabelSite () {
-    // Hack 1/14/25 to get compile
-    // const canEditCampaignXOwnedByOrganizationList = VoterStore.getCanEditCampaignXOwnedByOrganizationList();
-    // return canEditCampaignXOwnedByOrganizationList.includes(nonFluxState.siteOwnerOrganizationWeVoteId);
-    // End Hack 1/14/25 to get compile
-  },
-
-  voterExternalIdHasBeenSavedOnce (externalVoterId, membershipOrganizationWeVoteId) {
-    if (nonFluxState.voterExternalIdHasBeenSavedOnce[externalVoterId]) {
-      return nonFluxState.voterExternalIdHasBeenSavedOnce[externalVoterId][membershipOrganizationWeVoteId] || false;
-    } else {
-      return false;
-    }
-  },
-
-  voterFirstRetrieveInitiated () {
-    return nonFluxState.voterFirstRetrieveInitiated;
-  },
-
-  voterIsAdminForThisUrl () {
-    // Hack 1/14/25 to get compile
-    // const linkedOrganizationWeVoteId = VoterStore.getLinkedOrganizationWeVoteId();
-    // return nonFluxState.siteOwnerOrganizationWeVoteId === linkedOrganizationWeVoteId;
-    // End Hack 1/14/25 to get compile
-  },
-};
+// import { Subject } from 'rxjs';
+// // import VoterActions from '../actions/VoterActions'; // eslint-disable-line import/no-cycle
+// import stringContains from '../common/utils/stringContains';
+// import webAppConfig from '../config';
+// // import VoterStore from './VoterStore'; // eslint-disable-line import/no-cycle
+// import { dumpObjProps } from '../utils/appleSiliconUtils';
+// import $ajax from '../utils/service';
+//
+// const subject = new Subject();
+//
+// function isCordovaLocal () {
+//   const { cordova } = window;
+//   return cordova !== undefined;
+// }
+//
+// export const messageService = {
+//   sendMessage: (message) => subject.next({ text: message }),
+//   clearMessages: () => subject.next(),
+//   getMessage: () => subject.asObservable(),
+// };
+//
+// const nonFluxState = {
+//   activityTidbitWeVoteIdForDrawer: '',
+//   addPersonDrawerOpen: false,
+//   addPersonDrawerTeamId: -1, // Team ID used when adding a new person
+//   addTeamDrawerOpen: false,
+//   blockChallengeRedirectOnSignIn: false, // When signing in from the header, don't mark a challenge as supported
+//   challengeParticipantNameWithHighestRankByChallengeWeVoteId: {}, // Key is challengeWeVoteId, value is name for voter with the highest rank for that challenge
+//   challengeParticipantRankOfVoterByChallengeWeVoteId: {}, // Key is challengeWeVoteId, value is rank of voter for that challenge
+//   chosenDomainTypeIsCampaign: false,
+//   chosenGoogleAnalyticsTrackingID: false,
+//   chosenPreventSharingOpinions: false,
+//   chosenReadyIntroductionText: '',
+//   chosenReadyIntroductionTitle: '',
+//   chosenSiteLogoUrl: '',
+//   chosenWebsiteName: '',
+//   currentPathname: '',
+//   editPersonDrawerOpen: false,
+//   editPersonDrawerPersonId: -1,
+//   editPersonDrawerTeamId: -1,
+//   emailPersonalChanged: false,
+//   emailPersonalToBeSaved: '',
+//   firstNameChanged: false,
+//   firstNameToBeSaved: '',
+//   getStartedMode: '',
+//   getVoterGuideSettingsDashboardEditMode: '',
+//   googleAnalyticsEnabled: false,
+//   googleAnalyticsPending: false,
+//   hideOrganizationModalBallotItemInfo: false,
+//   hideOrganizationModalPositions: false,
+//   hideWeVoteLogo: false,
+//   hostname: '',
+//   lastNameChanged: false,
+//   lastNameToBeSaved: '',
+//   observableUpdateCounter: 0,
+//   openReplayEnabled: false,
+//   openReplayPending: false,
+//   openReplayTracker: undefined,
+//   openReplayVoterIsSignedIn: '',
+//   openReplayVoterWeVoteId: '',
+//   pendingSnackMessage: '',
+//   pendingSnackSeverity: '',
+//   recommendedCampaignListFirstRetrieveInitiated: false,
+//   scrolledDown: false,
+//   scrolledDownDrawer: false,
+//   setUpAccountBackLinkPath: '',
+//   setUpAccountEntryPath: '',
+//   whatAndHowMuchToShare: '',
+//   sharedItemCode: '',
+//   showActivityTidbitDrawer: false,
+//   showAdviserIntroModal: false,
+//   showAskFriendsModal: false,
+//   showChooseOrOpposeIntroModal: false,
+//   showCompleteYourProfileModal: false,
+//   showEditAddressButton: false,
+//   showElectionsWithOrganizationVoterGuidesModal: false,
+//   showHeader: 0,
+//   showHowItWorksModal: false,
+//   showNewVoterGuideModal: false,
+//   showOrganizationModal: false,
+//   showPaidAccountUpgradeModal: false,
+//   showPersonalizedScoreIntroModal: false,
+//   showPositionDrawer: false,
+//   showSelectBallotModal: false,
+//   showSelectBallotModalEditAddress: false,
+//   showShareModal: false,
+//   showSharedItemModal: false,
+//   showSignInModal: false,
+//   showTwitterLandingPage: false,
+//   showVoterPlanModal: false,
+//   signInStateChanged: false,
+//   siteConfigurationHasBeenRetrieved: false,
+//   siteOwnerOrganizationWeVoteId: '',
+//   storeSignInStartFullUrl: false,
+//   teamNameChanged: false,
+//   teamNameToBeSaved: '',
+//   viewingOrganizationVoterGuide: false,
+//   voterBallotItemsRetrieveHasBeenCalled: false,
+//   voterExternalIdHasBeenSavedOnce: {}, // Dict with externalVoterId and membershipOrganizationWeVoteId as keys, and true/false as value
+//   voterFirstRetrieveInitiated: false,
+// };
+//
+//
+// export default {
+//   blockChallengeRedirectOnSignIn () {
+//     return nonFluxState.blockChallengeRedirectOnSignIn;
+//   },
+//
+//   getActivityTidbitWeVoteIdForDrawer () {
+//     return nonFluxState.activityTidbitWeVoteIdForDrawer;
+//   },
+//
+//   getChallengeParticipantNameWithHighestRankByChallengeWeVoteId (challengeWeVoteId) {
+//     if (challengeWeVoteId && challengeWeVoteId in nonFluxState.challengeParticipantNameWithHighestRankByChallengeWeVoteId) {
+//       return nonFluxState.challengeParticipantNameWithHighestRankByChallengeWeVoteId[challengeWeVoteId];
+//     } else {
+//       return '';
+//     }
+//   },
+//
+//   getChallengeParticipantRankOfVoterByChallengeWeVoteId (challengeWeVoteId) {
+//     if (challengeWeVoteId && challengeWeVoteId in nonFluxState.challengeParticipantRankOfVoterByChallengeWeVoteId) {
+//       return nonFluxState.challengeParticipantRankOfVoterByChallengeWeVoteId[challengeWeVoteId];
+//     } else {
+//       return 0;
+//     }
+//   },
+//
+//   getChosenAboutOrganizationExternalUrl () {
+//     return nonFluxState.chosenAboutOrganizationExternalUrl;
+//   },
+//
+//   getChosenDomainTypeIsCampaign () {
+//     return nonFluxState.chosenDomainTypeIsCampaign;
+//   },
+//
+//   getChosenDomainTypeIsChallenge () {
+//     return false;
+//   },
+//
+//   getChosenGoogleAnalyticsTrackingID () {
+//     return nonFluxState.chosenGoogleAnalyticsTrackingID;
+//   },
+//
+//   getChosenPreventSharingOpinions () {
+//     return nonFluxState.chosenPreventSharingOpinions;
+//   },
+//
+//   getChosenReadyIntroductionText () {
+//     return nonFluxState.chosenReadyIntroductionText;
+//   },
+//
+//   getChosenReadyIntroductionTitle () {
+//     return nonFluxState.chosenReadyIntroductionTitle;
+//   },
+//
+//   getChosenSiteLogoUrl () {
+//     return nonFluxState.chosenSiteLogoUrl;
+//   },
+//
+//   getChosenWebsiteName () {
+//     return nonFluxState.chosenWebsiteName || 'WeVote.US'; // Used to be campaigns.WeVote.US on campaigns site
+//   },
+//
+//   getCurrentPathname () {
+//     return nonFluxState.currentPathname;
+//   },
+//
+//   getGlobalVariableState (globalVariableName) {
+//     return nonFluxState[globalVariableName];
+//   },
+//
+//   getGoogleAnalyticsEnabled () {
+//     return nonFluxState.googleAnalyticsEnabled;
+//   },
+//
+//   getGoogleAnalyticsPending () {
+//     return nonFluxState.googleAnalyticsPending;
+//   },
+//
+//   getOpenReplayEnabled () {
+//     return nonFluxState.openReplayEnabled;
+//   },
+//
+//   getOpenReplayPending () {
+//     return nonFluxState.openReplayPending;
+//   },
+//
+//   getOpenReplayStateCode () {
+//     return nonFluxState.stateCode;
+//   },
+//
+//   getOpenReplayStateCodeFromIpAddress () {
+//     return nonFluxState.stateCodeFromIpAddress;
+//   },
+//
+//   getOpenReplayTracker () {
+//     return nonFluxState.openReplayTracker;
+//   },
+//
+//   getOpenReplayVoterIsSignedIn () {
+//     return nonFluxState.openReplayVoterIsSignedIn;
+//   },
+//
+//   getOpenReplayVoterWeVoteId () {
+//     return nonFluxState.openReplayVoterWeVoteId;
+//   },
+//
+//   getHideWeVoteLogo () {
+//     return nonFluxState.hideWeVoteLogo;
+//   },
+//
+//   getHostname () {
+//     return nonFluxState.hostname || '';
+//   },
+//
+//   getPendingSnackMessage () {
+//     return nonFluxState.pendingSnackMessage;
+//   },
+//
+//   getPendingSnackSeverity () {
+//     return nonFluxState.pendingSnackSeverity;
+//   },
+//
+//   getScrolledDown () {
+//     return nonFluxState.scrolledDown;
+//   },
+//
+//   getScrolledDownDrawer () {
+//     return nonFluxState.scrolledDownDrawer;
+//   },
+//
+//   getSetUpAccountBackLinkPath () {
+//     return nonFluxState.setUpAccountBackLinkPath;
+//   },
+//
+//   getSetUpAccountEntryPath () {
+//     return nonFluxState.setUpAccountEntryPath;
+//   },
+//
+//   getSharedItemCode () {
+//     return nonFluxState.sharedItemCode;
+//   },
+//
+//   getShareModalStep () {
+//     // console.log('AppObservableStore shareModalStep:', nonFluxState.shareModalStep);
+//     return nonFluxState.shareModalStep;
+//   },
+//
+//   getWeVoteRootURL () {
+//     const { location: { hostname, origin } } = window;
+//     if (hostname === 'localhost' || hostname === 'quality.wevote.us' || hostname === 'wevotedeveloper.com') {
+//       return origin; // ex/ https://localhost:3000
+//     } else {
+//       return 'https://wevote.us';
+//     }
+//   },
+//
+//   getWhatAndHowMuchToShare () {
+//     // console.log('getWhatAndHowMuchToShare:', nonFluxState.whatAndHowMuchToShare);
+//     return nonFluxState.whatAndHowMuchToShare;
+//   },
+//
+//   getShowTwitterLandingPage () {
+//     // console.log('AppObservableStore getShowTwitterLandingPage:', nonFluxState.showTwitterLandingPage);
+//     return nonFluxState.showTwitterLandingPage;
+//   },
+//
+//   getSignInStateChanged () {
+//     return nonFluxState.signInStateChanged;
+//   },
+//
+//   getSiteOwnerOrganizationWeVoteId () {
+//     return nonFluxState.siteOwnerOrganizationWeVoteId;
+//   },
+//
+//   getStartedMode () {
+//     return nonFluxState.getStartedMode;
+//   },
+//
+//   getVoterGuideSettingsDashboardEditMode () {
+//     return nonFluxState.getVoterGuideSettingsDashboardEditMode;
+//   },
+//
+//   hideOrganizationModalBallotItemInfo () {
+//     return nonFluxState.hideOrganizationModalBallotItemInfo;
+//   },
+//
+//   hideOrganizationModalPositions () {
+//     return nonFluxState.hideOrganizationModalPositions;
+//   },
+//
+//   inPrivateLabelMode () {
+//     return Boolean(nonFluxState.chosenSiteLogoUrl || false);
+//   },
+//
+//   isSnackMessagePending () {
+//     return nonFluxState.pendingSnackMessage && nonFluxState.pendingSnackMessage.length > 0;
+//   },
+//
+//   isOnWeVoteRootUrl () {
+//     // console.log('AppObservableStore nonFluxState.onWeVoteRootUrl: ', nonFluxState.onWeVoteRootUrl,
+//     //   ', isOnWeVoteRootUrl weVoteURL: ', weVoteURL,
+//     //   ', isCordovaLocal(): ', isCordovaLocal());
+//
+//     const { location: { href: hrefValue } } = window;
+//     // console.log('AppObservableStore hrefValue: ', hrefValue);
+//     const hrefValueLowerCase = (hrefValue) ? hrefValue.toLowerCase() : '';
+//     return (nonFluxState.onWeVoteRootUrl || false) ||
+//       isCordovaLocal() ||
+//       stringContains('quality.wevote.us:', hrefValueLowerCase) ||
+//       stringContains('www.wevote.us:', hrefValueLowerCase) ||
+//       stringContains('//wevote.us:', hrefValueLowerCase) ||
+//       stringContains('wevote.org:', hrefValueLowerCase) ||
+//       stringContains('localhost:', hrefValueLowerCase) ||
+//       stringContains('wevotedeveloper.com:', hrefValueLowerCase) ||
+//       stringContains('ngrok.io', hrefValueLowerCase) ||
+//       stringContains('ngrok-free.app', hrefValueLowerCase);
+//   },
+//
+//   isOnFacebookJsSdkHostDomainList () {
+//     const { hostname } = window.location;
+//     const hostnameLowerCase = (hostname) ? hostname.toLowerCase() : '';
+//     const hostnameFiltered = hostnameLowerCase.replace('www.', '');
+//     // console.log('----------------------', hostname);
+//     return hostnameFiltered === 'wevote.us' ||
+//       hostnameFiltered === 'quality.wevote.us' ||
+//       hostnameFiltered === 'localhost' ||
+//       hostnameFiltered === 'wevotedeveloper.com' ||
+//       isCordovaLocal() ||
+//       window.location.href.includes('ngrok');
+//   },
+//
+//   isOnWeVotePartnerSubdomainUrl () {
+//     // console.log('AppObservableStore isOnWeVotePartnerSubdomainUrl: ', nonFluxState.onWeVotePartnerSubdomainUrl);
+//     return nonFluxState.onWeVotePartnerSubdomainUrl;
+//   },
+//
+//   isOnPartnerUrl () {
+//     // console.log('AppObservableStore onWeVotePartnerSubdomainUrl: ', nonFluxState.onWeVotePartnerSubdomainUrl, ', onChosenFullDomainUrl:', nonFluxState.onChosenFullDomainUrl);
+//     return nonFluxState.onWeVotePartnerSubdomainUrl || nonFluxState.onChosenFullDomainUrl;
+//   },
+//
+//   isVoterAdminForThisUrl (linkedOrganizationWeVoteId) {
+//     // const linkedOrganizationWeVoteId = VoterStore.getLinkedOrganizationWeVoteId();
+//     return nonFluxState.siteOwnerOrganizationWeVoteId === linkedOrganizationWeVoteId;
+//   },
+//
+//   isOnFacebookSupportedDomainUrl () {
+//     return nonFluxState.onFacebookSupportedDomainUrl;
+//   },
+//
+//   isOnChosenFullDomainUrl () {
+//     return nonFluxState.onChosenFullDomainUrl;
+//   },
+//
+//   recommendedCampaignListFirstRetrieveInitiated () {
+//     return nonFluxState.recommendedCampaignListFirstRetrieveInitiated;
+//   },
+//
+//   incrementObservableUpdateCounter () {
+//     nonFluxState.observableUpdateCounter += 1;
+//     messageService.sendMessage('state incremented ObservableUpdateCounter');
+//   },
+//
+//   setActivityTidbitWeVoteIdForDrawer (activityTidbitWeVoteId) {
+//     nonFluxState.activityTidbitWeVoteIdForDrawer = activityTidbitWeVoteId;
+//     messageService.sendMessage('state updated activityTidbitWeVoteIdForDrawer');
+//   },
+//
+//   setActivityTidbitWeVoteIdForDrawerAndOpen (setActivityTidbitWeVoteIdForDrawerAndOpen) {
+//     nonFluxState.activityTidbitWeVoteIdForDrawerAndOpen = setActivityTidbitWeVoteIdForDrawerAndOpen;
+//     messageService.sendMessage('state updated activityTidbitWeVoteIdForDrawerAndOpen');
+//   },
+//
+//   setBlockChallengeRedirectOnSignIn (value) {
+//     nonFluxState.blockChallengeRedirectOnSignIn = value;
+//     messageService.sendMessage('state updated blockChallengeRedirectOnSignIn');
+//   },
+//
+//   setChallengeParticipantRankOfVoter (challengeWeVoteId, rank) {
+//     // console.log('setChallengeParticipantRankOfVoter: ', challengeWeVoteId, ', rank: ', rank);
+//     nonFluxState.challengeParticipantRankOfVoterByChallengeWeVoteId[challengeWeVoteId] = rank;
+//     messageService.sendMessage('state updated challengeParticipantRankOfVoterByChallengeWeVoteId');
+//   },
+//
+//   setChallengeParticipantNameWithHighestRank (challengeWeVoteId, voterName) {
+//     // console.log('setChallengeParticipantNameWithHighestRank: ', challengeWeVoteId, ', voterName: ', voterName);
+//     nonFluxState.challengeParticipantNameWithHighestRankByChallengeWeVoteId[challengeWeVoteId] = voterName;
+//     messageService.sendMessage('state updated challengeParticipantNameWithHighestRankByChallengeWeVoteId');
+//   },
+//
+//   setCurrentPathname (currentPathname) {
+//     nonFluxState.currentPathname = currentPathname;
+//     messageService.sendMessage('state updated currentPathname');
+//   },
+//
+//   setEvaluateHeaderDisplay () {
+//     // Force the Header to evaluate whether it should display
+//     nonFluxState.showHeader = Date.now();
+//     messageService.sendMessage('state updated showHeader');
+//   },
+//
+//   setGetStartedMode (getStartedMode) {
+//     nonFluxState.getStartedMode = getStartedMode;
+//     messageService.sendMessage('state updated getStartedMode');
+//   },
+//
+//   setGlobalVariableState (globalVariableName, newState) {
+//     nonFluxState[globalVariableName] = newState;
+//     messageService.sendMessage(`state updated ${globalVariableName}`);
+//   },
+//
+//   setGlobalVariableStateInBulk (globalVariableStateDict) {
+//     const keys = Object.keys(globalVariableStateDict);
+//     const values = Object.values(globalVariableStateDict);
+//     for (let i = 0; i < keys.length; i++) {
+//       nonFluxState[keys[i]] = values[i];
+//     }
+//     messageService.sendMessage('state updated multiple global variables');
+//   },
+//
+//   setHideOrganizationModalBallotItemInfo (hide) {
+//     nonFluxState.hideOrganizationModalBallotItemInfo = hide;
+//     messageService.sendMessage('state updated hideOrganizationModalBallotItemInfo');
+//   },
+//
+//   setHideOrganizationModalPositions (hide) {
+//     nonFluxState.hideOrganizationModalPositions = hide;
+//     messageService.sendMessage('state updated hideOrganizationModalPositions');
+//   },
+//
+//   setGoogleAnalyticsEnabled (enabled) {
+//     nonFluxState.googleAnalyticsEnabled = enabled;
+//     messageService.sendMessage('state updated googleAnalyticsEnabled');
+//   },
+//
+//   setGoogleAnalyticsPending (enabled) {
+//     nonFluxState.googleAnalyticsPending = enabled;
+//     messageService.sendMessage('state updated googleAnalyticsPending');
+//   },
+//
+//   setOpenReplayEnabled (enabled) {
+//     nonFluxState.openReplayEnabled = enabled;
+//     messageService.sendMessage('state updated openReplayEnabled');
+//   },
+//
+//   setOpenReplayPending (enabled) {
+//     nonFluxState.openReplayPending = enabled;
+//     messageService.sendMessage('state updated openReplayPending');
+//   },
+//
+//   setOpenReplayStateCode (stateCode) {
+//     nonFluxState.stateCode = stateCode;
+//     messageService.sendMessage('state updated stateCode');
+//   },
+//
+//   setOpenReplayStateCodeFromIpAddress (stateCodeFromIpAddress) {
+//     nonFluxState.stateCodeFromIpAddress = stateCodeFromIpAddress;
+//     messageService.sendMessage('state updated stateCodeFromIpAddress');
+//   },
+//
+//   setOpenReplayTracker (tracker) {
+//     nonFluxState.openReplayTracker = tracker;
+//     messageService.sendMessage('state updated openReplayTracker');
+//   },
+//
+//   setOpenReplayVoterIsSignedIn (value) {
+//     nonFluxState.openReplayVoterIsSignedIn = value;
+//     messageService.sendMessage('state updated openReplayVoterIsSignedIn');
+//   },
+//
+//   setOpenReplayVoterWeVoteId (value) {
+//     nonFluxState.openReplayVoterWeVoteId = value;
+//     messageService.sendMessage('state updated openReplayVoterWeVoteId');
+//   },
+//
+//   setPendingSnackMessage (message, severity) {
+//     nonFluxState.pendingSnackMessage = message;
+//     nonFluxState.pendingSnackSeverity = severity;
+//   },
+//
+//   setRecommendedCampaignListFirstRetrieveInitiated (value) {
+//     nonFluxState.recommendedCampaignListFirstRetrieveInitiated = value;
+//     messageService.sendMessage('state updated recommendedCampaignListFirstRetrieveInitiated');
+//   },
+//
+//   setScrolled (scrolledDown) {
+//     nonFluxState.scrolledDown = scrolledDown;
+//     messageService.sendMessage('state updated scrolledDown');
+//   },
+//
+//   setScrolledDownDrawer (scrolledDown) {
+//     nonFluxState.scrolledDownDrawer = scrolledDown;
+//     messageService.sendMessage('state updated scrolledDownDrawer');
+//   },
+//
+//   setSetUpAccountBackLinkPath (backLinkPath) {
+//     // console.log('setSetUpAccountBackLinkPath, step:', step);
+//     nonFluxState.setUpAccountBackLinkPath = backLinkPath;
+//     messageService.sendMessage('state updated setUpAccountBackLinkPath');
+//   },
+//
+//   setSetUpAccountEntryPath (entryPath) {
+//     // console.log('setSetUpAccountEntryPath, step:', step);
+//     nonFluxState.setUpAccountEntryPath = entryPath;
+//     messageService.sendMessage('state updated setSetUpAccountEntryPath');
+//   },
+//
+//   setShowActivityTidbitDrawer (show) {
+//     nonFluxState.showActivityTidbitDrawer = show;
+//     messageService.sendMessage('state updated showActivityTidbitDrawer');
+//   },
+//
+//   setShowAdviserIntroModal (show) {
+//     nonFluxState.showAdviserIntroModal = show;
+//     messageService.sendMessage('state updated showAdviserIntroModal');
+//   },
+//
+//   setShowAskFriendsModal (show) {
+//     nonFluxState.showAskFriendsModal = show;
+//     messageService.sendMessage('state updated showAskFriendsModal');
+//   },
+//
+//   setShowChallengeThanksForJoining (show) {
+//     nonFluxState.showChallengeThanksForJoining = show;
+//     messageService.sendMessage('state updated showChallengeThanksForJoining');
+//   },
+//
+//   setShowChooseOrOpposeIntroModal (show, ballotItemType = 'CANDIDATE') {
+//     nonFluxState.showChooseOrOpposeIntroModal = show;
+//     nonFluxState.showChooseOrOpposeIntroModalBallotItemType = ballotItemType;
+//     messageService.sendMessage('state updated showChooseOrOpposeIntroModal');
+//   },
+//
+//   setShowCompleteYourProfileModal (show) {
+//     nonFluxState.showCompleteYourProfileModal = show;
+//     messageService.sendMessage('state updated showCompleteYourProfileModal');
+//   },
+//
+//   setShowEditAddressButton (show) {
+//     nonFluxState.showEditAddressButton = show;
+//     messageService.sendMessage('state updated showEditAddressButton');
+//   },
+//
+//   setShowElectionsWithOrganizationVoterGuidesModal (show) {
+//     nonFluxState.showElectionsWithOrganizationVoterGuidesModal = show;
+//     messageService.sendMessage('state updated showElectionsWithOrganizationVoterGuidesModal');
+//   },
+//
+//   setShowFirstPositionIntroModal (show) {
+//     nonFluxState.showFirstPositionIntroModal = show;
+//     messageService.sendMessage('state updated showFirstPositionIntroModal');
+//   },
+//
+//   setShowHowItWorksModal (show) {
+//     // The chosenPaidAccount values are: free, professional, enterprise
+//     nonFluxState.showHowItWorksModal = show;
+//     messageService.sendMessage('state updated showHowItWorksModal');
+//   },
+//
+//   setShowImageUploadModal (show) {
+//     // console.log('Setting image upload modal to open!');
+//     nonFluxState.showImageUploadModal = show;
+//     messageService.sendMessage('state updated showImageUploadModal');
+//   },
+//
+//   setShowNewVoterGuideModal (show) {
+//     nonFluxState.showNewVoterGuideModal = show;
+//     messageService.sendMessage('state updated showNewVoterGuideModal');
+//   },
+//
+//   setShowOrganizationModal (show) {
+//     // console.log("Setting organizationModal to ", show);
+//     nonFluxState.showOrganizationModal = show;
+//     messageService.sendMessage('state updated showOrganizationModal');
+//   },
+//
+//   setShowPaidAccountUpgradeModal (chosenPaidAccount) {
+//     // The chosenPaidAccount values are: free, professional, enterprise
+//     nonFluxState.showPaidAccountUpgradeModal = chosenPaidAccount;
+//     messageService.sendMessage('state updated showPaidAccountUpgradeModal');
+//   },
+//
+//   setShowPersonalizedScoreIntroModal (show) {
+//     nonFluxState.showPersonalizedScoreIntroModal = show;
+//     messageService.sendMessage('state updated showPersonalizedScoreIntroModal');
+//   },
+//
+//   setShowPositionDrawer (show) {
+//     nonFluxState.showPositionDrawer = show;
+//     messageService.sendMessage('state updated showPositionDrawer');
+//   },
+//
+//   setShowSelectBallotModal (showSelectBallotModal, showSelectBallotModalEditAddress = false) {
+//     nonFluxState.showSelectBallotModalEditAddress = showSelectBallotModalEditAddress;
+//     nonFluxState.showSelectBallotModal = showSelectBallotModal;
+//     // console.log('setShowSelectBallotModal showSelectBallotModalEditAddress:', showSelectBallotModalEditAddress);
+//     messageService.sendMessage('state updated showSelectBallotModal, showSelectBallotModalEditAddress');
+//   },
+//
+//   setShowSelectBallotModalOnly (showSelectBallotModal) {
+//     nonFluxState.showSelectBallotModal = showSelectBallotModal;
+//     messageService.sendMessage('state updated showSelectBallotModalOnly');
+//   },
+//
+//   setShowShareModal (show) {
+//     // The chosenPaidAccount values are: free, professional, enterprise
+//     nonFluxState.showShareModal = show;
+//     messageService.sendMessage('state updated showShareModal');
+//   },
+//
+//   setShowSharedItemModal (sharedItemCode) {
+//     nonFluxState.sharedItemCode = sharedItemCode;
+//     nonFluxState.showSharedItemModal = Boolean(sharedItemCode);
+//     messageService.sendMessage('state updated showSharedItemModal');
+//   },
+//
+//   setShowSignInModal (show) {
+//     nonFluxState.showSignInModal = show;
+//     messageService.sendMessage('state updated showSignInModal');
+//   },
+//
+//   setShowTwitterLandingPage (show) {
+//     nonFluxState.showTwitterLandingPage = show;
+//     messageService.sendMessage('state updated showTwitterLandingPage');
+//   },
+//
+//   setShowValuesIntroModal (show) {
+//     nonFluxState.showValuesIntroModal = show;
+//     messageService.sendMessage('state updated showValuesIntroModal');
+//   },
+//
+//   setShowVoterPlanModal (show) {
+//     // The chosenPaidAccount values are: free, professional, enterprise
+//     nonFluxState.showVoterPlanModal = show;
+//     messageService.sendMessage('state updated showVoterPlanModal');
+//   },
+//
+//   setSignInStateChanged (signin) {
+//     nonFluxState.signInStateChanged = signin;
+//     messageService.sendMessage('state updated signInStateChanged');
+//   },
+//
+//   setSignInStartFullUrl () {
+//     nonFluxState.storeSignInStartFullUrl = true;
+//     messageService.sendMessage('state updated storeSignInStartFullUrl');
+//   },
+//
+//   setStoreSignInStartFullUrl () {
+//     nonFluxState.storeSignInStartFullUrl = true;
+//     messageService.sendMessage('state updated storeSignInStartFullUrl');
+//   },
+//
+//   setViewingOrganizationVoterGuide (isViewing) {
+//     nonFluxState.viewingOrganizationVoterGuide = isViewing;
+//     messageService.sendMessage('state updated viewingOrganizationVoterGuide');
+//   },
+//
+//   setVoterGuideSettingsDashboardEditMode (getVoterGuideSettingsDashboardEditMode) {
+//     nonFluxState.getVoterGuideSettingsDashboardEditMode = getVoterGuideSettingsDashboardEditMode;
+//     messageService.sendMessage('state updated getVoterGuideSettingsDashboardEditMode');
+//   },
+//
+//   setVoterBallotItemsRetrieveHasBeenCalled (voterBallotItemsRetrieveHasBeenCalled) {
+//     nonFluxState.voterBallotItemsRetrieveHasBeenCalled = voterBallotItemsRetrieveHasBeenCalled;
+//     messageService.sendMessage('state updated voterBallotItemsRetrieveHasBeenCalled');
+//   },
+//
+//   setVoterFirstRetrieveInitiated (voterFirstRetrieveInitiated) {
+//     nonFluxState.voterFirstRetrieveInitiated = voterFirstRetrieveInitiated;
+//     messageService.sendMessage('state updated voterFirstRetrieveInitiated');
+//   },
+//
+//   setWhatAndHowMuchToShare (step) {
+//     // console.log('setWhatAndHowMuchToShare, step:', step);
+//     nonFluxState.whatAndHowMuchToShare = step;
+//     messageService.sendMessage('state updated whatAndHowMuchToShare');
+//   },
+//
+//   showActivityTidbitDrawer () {
+//     return nonFluxState.showActivityTidbitDrawer;
+//   },
+//
+//   showAdviserIntroModal () {
+//     return nonFluxState.showAdviserIntroModal;
+//   },
+//
+//   showAskFriendsModal () {
+//     return nonFluxState.showAskFriendsModal;
+//   },
+//
+//   showChallengeThanksForJoining () {
+//     return nonFluxState.showChallengeThanksForJoining;
+//   },
+//
+//   showChooseOrOpposeIntroModal () {
+//     return nonFluxState.showChooseOrOpposeIntroModal;
+//   },
+//
+//   showCompleteYourProfileModal () {
+//     return nonFluxState.showCompleteYourProfileModal;
+//   },
+//
+//   // showEditAddressButton () {
+//   //   return nonFluxState.showEditAddressButton;
+//   // },
+//
+//   showElectionsWithOrganizationVoterGuidesModal () {
+//     return nonFluxState.showElectionsWithOrganizationVoterGuidesModal;
+//   },
+//
+//   showFirstPositionIntroModal () {
+//     return nonFluxState.showFirstPositionIntroModal;
+//   },
+//
+//   showHowItWorksModal () {
+//     return nonFluxState.showHowItWorksModal;
+//   },
+//
+//   showingOneCompleteYourProfileModal () {
+//     return nonFluxState.showAdviserIntroModal ||
+//       nonFluxState.showFirstPositionIntroModal ||
+//       nonFluxState.showHowItWorksModal ||
+//       nonFluxState.showPersonalizedScoreIntroModal ||
+//       nonFluxState.showSelectBallotModal ||
+//       nonFluxState.showSharedItemModal ||
+//       nonFluxState.showValuesIntroModal;
+//   },
+//
+//   showNewVoterGuideModal () {
+//     return nonFluxState.showNewVoterGuideModal;
+//   },
+//
+//   showPaidAccountUpgradeModal () {
+//     // The chosenPaidAccount values are: free, professional, enterprise
+//     return nonFluxState.showPaidAccountUpgradeModal;
+//   },
+//
+//   showPersonalizedScoreIntroModal () {
+//     return nonFluxState.showPersonalizedScoreIntroModal;
+//   },
+//
+//   showPositionDrawer () {
+//     return nonFluxState.showPositionDrawer;
+//   },
+//
+//   showShareModal () {
+//     return nonFluxState.showShareModal;
+//   },
+//
+//   showSharedItemModal () {
+//     return nonFluxState.showSharedItemModal;
+//   },
+//
+//   showSelectBallotModal () {
+//     return nonFluxState.showSelectBallotModal;
+//   },
+//
+//   showSelectBallotModalEditAddress () {
+//     return nonFluxState.showSelectBallotModalEditAddress;
+//   },
+//
+//   showSignInModal () {
+//     return nonFluxState.showSignInModal;
+//   },
+//
+//   showOrganizationModal () {
+//     return nonFluxState.showOrganizationModal;
+//   },
+//
+//   showValuesIntroModal () {
+//     return nonFluxState.showValuesIntroModal;
+//   },
+//
+//   showImageUploadModal () {
+//     return nonFluxState.showImageUploadModal;
+//   },
+//
+//   showVoterPlanModal () {
+//     return nonFluxState.showVoterPlanModal;
+//   },
+//
+//   siteConfigurationHasBeenRetrieved () {
+//     // let { hostname } = window.location;
+//     // hostname = hostname || '';
+//     // if (hostname === 'campaigns.wevote.us') {
+//     //   // Bypass for default site
+//     //   return true;
+//     // } else {
+//     //   return nonFluxState.siteConfigurationHasBeenRetrieved;
+//     // }
+//     return nonFluxState.siteConfigurationHasBeenRetrieved;
+//   },
+//
+//   siteConfigurationRetrieve (hostname, externalVoterId = '', refresh_string = '') {
+//     $ajax({
+//       endpoint: 'siteConfigurationRetrieve',
+//       data: { hostname, refresh_string },
+//       success: (res) => {
+//         // console.log('AppObservableStore siteConfigurationRetrieve success, res:', res);
+//         const {
+//           status: apiStatus,
+//           success: apiSuccess,
+//           hostname: hostFromApi,
+//           organization_we_vote_id: siteOwnerOrganizationWeVoteId,
+//           chosen_about_organization_external_url: chosenAboutOrganizationExternalUrl,
+//           chosen_domain_type_is_campaign: chosenDomainTypeIsCampaign,
+//           chosen_google_analytics_tracking_id: chosenGoogleAnalyticsTrackingID,
+//           chosen_hide_we_vote_logo: hideWeVoteLogo,
+//           chosen_logo_url_https: chosenSiteLogoUrl,
+//           chosen_prevent_sharing_opinions: chosenPreventSharingOpinions,
+//           chosen_ready_introduction_text: chosenReadyIntroductionText,
+//           chosen_ready_introduction_title: chosenReadyIntroductionTitle,
+//           chosen_website_name: chosenWebsiteName,
+//         } = res;
+//         let newHostname = hostFromApi ? hostFromApi.replace('www.', '') : hostname.replace('www.', '');
+//         if (apiSuccess) {
+//           let onWeVoteRootUrl = false;
+//           let onWeVotePartnerSubdomainUrl = false;
+//           let onFacebookSupportedDomainUrl = false;
+//           let onChosenFullDomainUrl = false;
+//
+//           if (isCordovaLocal()) {
+//             newHostname = webAppConfig.HOSTNAME;
+//           }
+//
+//           onWeVoteRootUrl = this.isOnWeVoteRootUrl();
+//           // console.log('AppObservableStore siteConfigurationRetrieve hostname, newHostname:', hostname, newHostname, ', onWeVoteRootUrl:', onWeVoteRootUrl);
+//           if (!onWeVoteRootUrl && stringContains('wevote.us', newHostname)) {
+//             onWeVotePartnerSubdomainUrl = true;
+//           } else if (!onWeVoteRootUrl) {
+//             onChosenFullDomainUrl = true;
+//           }
+//           onFacebookSupportedDomainUrl = this.isOnFacebookJsSdkHostDomainList();
+//           // console.log('AppObservableStore siteConfigurationRetrieve onFacebookSupportedDomainUrl:', onFacebookSupportedDomainUrl);
+//           // console.log('AppObservableStore externalVoterId:', externalVoterId, ', siteOwnerOrganizationWeVoteId:', siteOwnerOrganizationWeVoteId);
+//           const { voterExternalIdHasBeenSavedOnce } = nonFluxState;
+//           if (externalVoterId && siteOwnerOrganizationWeVoteId) {
+//             if (!this.voterExternalIdHasBeenSavedOnce(externalVoterId, siteOwnerOrganizationWeVoteId)) {
+//               // console.log('voterExternalIdHasBeenSavedOnce has NOT been saved before.');
+//               // Hack 1/14/25 VoterActions.voterExternalIdSave(externalVoterId, siteOwnerOrganizationWeVoteId);
+//               if (!voterExternalIdHasBeenSavedOnce[externalVoterId]) {
+//                 voterExternalIdHasBeenSavedOnce[externalVoterId] = {};
+//               }
+//               voterExternalIdHasBeenSavedOnce[externalVoterId][siteOwnerOrganizationWeVoteId] = true;
+//               // AnalyticsActions.saveActionBallotVisit(VoterStore.electionId());
+//             } else {
+//               // console.log('voterExternalIdHasBeenSavedOnce has been saved before.');
+//             }
+//           }
+//           nonFluxState.apiStatus = apiStatus;
+//           nonFluxState.apiSuccess = apiSuccess;
+//           nonFluxState.chosenAboutOrganizationExternalUrl = chosenAboutOrganizationExternalUrl;
+//           nonFluxState.chosenDomainTypeIsCampaign = chosenDomainTypeIsCampaign;
+//           nonFluxState.chosen_google_analytics_tracking_id = chosenGoogleAnalyticsTrackingID;
+//           nonFluxState.chosenPreventSharingOpinions = chosenPreventSharingOpinions;
+//           nonFluxState.chosenReadyIntroductionText = chosenReadyIntroductionText;
+//           nonFluxState.chosenReadyIntroductionTitle = chosenReadyIntroductionTitle;
+//           nonFluxState.chosenSiteLogoUrl = chosenSiteLogoUrl;
+//           nonFluxState.chosenWebsiteName = chosenWebsiteName;
+//           nonFluxState.hideWeVoteLogo = hideWeVoteLogo;
+//           nonFluxState.hostname = newHostname;
+//           nonFluxState.onChosenFullDomainUrl = onChosenFullDomainUrl;
+//           nonFluxState.onFacebookSupportedDomainUrl = onFacebookSupportedDomainUrl;
+//           nonFluxState.onWeVotePartnerSubdomainUrl = onWeVotePartnerSubdomainUrl;
+//           nonFluxState.onWeVoteRootUrl = onWeVoteRootUrl;
+//           nonFluxState.siteConfigurationHasBeenRetrieved = true;
+//           nonFluxState.siteOwnerOrganizationWeVoteId = siteOwnerOrganizationWeVoteId;
+//           nonFluxState.voterExternalIdHasBeenSavedOnce = voterExternalIdHasBeenSavedOnce;
+//           messageService.sendMessage('state updated for siteConfigurationRetrieve');
+//         }
+//       },
+//
+//       error: (res) => {
+//         console.error('AppObservableStore error: ', res);
+//         dumpObjProps('AppObservableStore error', res);
+//       },
+//     });
+//   },
+//
+//   storeSignInStartFullUrl () {
+//     return nonFluxState.storeSignInStartFullUrl;
+//   },
+//
+//   unsetStoreSignInStartFullUrl () {
+//     nonFluxState.unsetStoreSignInStartFullUrl = false;
+//     messageService.sendMessage('state updated unsetStoreSignInStartFullUrl');
+//   },
+//
+//   voterBallotItemsRetrieveHasBeenCalled () {
+//     return nonFluxState.voterBallotItemsRetrieveHasBeenCalled;
+//   },
+//
+//   voterCanStartCampaignXForThisPrivateLabelSite () {
+//     // Hack 1/14/25 to get compile
+//     // const canEditCampaignXOwnedByOrganizationList = VoterStore.getCanEditCampaignXOwnedByOrganizationList();
+//     // return canEditCampaignXOwnedByOrganizationList.includes(nonFluxState.siteOwnerOrganizationWeVoteId);
+//     // End Hack 1/14/25 to get compile
+//   },
+//
+//   voterExternalIdHasBeenSavedOnce (externalVoterId, membershipOrganizationWeVoteId) {
+//     if (nonFluxState.voterExternalIdHasBeenSavedOnce[externalVoterId]) {
+//       return nonFluxState.voterExternalIdHasBeenSavedOnce[externalVoterId][membershipOrganizationWeVoteId] || false;
+//     } else {
+//       return false;
+//     }
+//   },
+//
+//   voterFirstRetrieveInitiated () {
+//     return nonFluxState.voterFirstRetrieveInitiated;
+//   },
+//
+//   voterIsAdminForThisUrl () {
+//     // Hack 1/14/25 to get compile
+//     // const linkedOrganizationWeVoteId = VoterStore.getLinkedOrganizationWeVoteId();
+//     // return nonFluxState.siteOwnerOrganizationWeVoteId === linkedOrganizationWeVoteId;
+//     // End Hack 1/14/25 to get compile
+//   },
+// };

--- a/src/js/stores/PersonStore.js
+++ b/src/js/stores/PersonStore.js
@@ -1,296 +1,296 @@
-import { ReduceStore } from 'flux/utils';
-import Dispatcher from '../common/dispatcher/Dispatcher';
-import Cookies from '../common/utils/js-cookie/Cookies';
-import arrayContains from '../common/utils/arrayContains';
-
-class PersonStore extends ReduceStore {
-  getInitialState () {
-    return {
-      allPeopleCache: {}, // This is a dictionary key: personId, value: person dict
-      mostRecentPersonIdSaved: -1,
-      mostRecentPersonSaved: {
-        firstName: '',
-        lastName: '',
-        personId: '',
-      },
-      searchResults: [],
-    };
-  }
-
-  getAllCachedPeopleList () {
-    const { allPeopleCache } = this.getState();
-    const personListRaw = Object.values(allPeopleCache);
-
-    const personList = [];
-    let personFiltered;
-    let personRaw;
-    for (let i = 0; i < personListRaw.length; i++) {
-      personRaw = personListRaw[i];
-      // console.log('PersonStore getAllCachedPeopleList person:', person);
-      personFiltered = personRaw;
-      personList.push(personFiltered);
-    }
-    return personList;
-  }
-
-  getFirstName (personId) {
-    const person = this.getPersonById(personId);
-    return person.firstName || '';
-  }
-
-  getFullNamePreferred (personId) {
-    const person = this.getPersonById(personId);
-    let fullName = '';
-    if (person.id >= 0) {
-      if (person.firstNamePreferred) {
-        fullName += person.firstNamePreferred;
-      } else if (person.firstName) {
-        fullName += person.firstName;
-      }
-      if (fullName.length > 0 && person.lastName) {
-        fullName += ' ';
-      }
-      if (person.lastName) {
-        fullName += person.lastName;
-      }
-    }
-    return fullName;
-  }
-
-  getFirstPlusLastName (personId) {
-    const storedFirstName = this.getFirstName(personId);
-    const storedLastName = this.getLastName(personId);
-    let displayName = '';
-    if (storedFirstName && String(storedFirstName) !== '') {
-      displayName = storedFirstName;
-      if (storedLastName && String(storedLastName) !== '') {
-        displayName += ' ';
-      }
-    }
-    if (storedLastName && String(storedLastName) !== '') {
-      displayName += storedLastName;
-    }
-    return displayName;
-  }
-
-  getLastName (personId) {
-    const person = this.getPersonById(personId);
-    return person.lastName || '';
-  }
-
-  getMostRecentPersonChanged () {
-    // console.log('PersonStore getMostRecentPersonChanged Id:', this.getState().mostRecentPersonIdSaved);
-    if (this.getState().mostRecentPersonIdSaved !== -1) {
-      return this.getPersonById(this.getState().mostRecentPersonIdSaved);
-    }
-    return {};
-  }
-
-  getPersonById (personId) {
-    const { allPeopleCache } = this.getState();
-    // console.log('PersonStore getPersonById:', personId, ', allPeopleCache:', allPeopleCache);
-    return allPeopleCache[personId] || {};
-  }
-
-  getPersonDeviceId () {
-    return this.getState().person.personDeviceId || Cookies.get('personDeviceId');
-  }
-
-  getStateCode (personId) {
-    const person = this.getPersonById(personId);
-    return person.stateCode || '';
-  }
-
-  getSearchResults () {
-    // console.log('PersonStore getSearchResults:', this.getState().searchResults);
-    return this.getState().searchResults || [];
-  }
-
-  getSignedInPersonId () {
-    // TODO: Implement this logic
-  }
-
-  reduce (state, action) {
-    const { allPeopleCache } = state;
-    let personTemp = {};
-    let personId = -1;
-    let revisedState = state;
-    let searchResults = [];
-    let teamId = -1;
-    let teamList = [];
-    let teamMemberList = [];
-
-    switch (action.type) {
-      case 'add-person-to-team':
-        if (!action.res.success) {
-          console.log('PersonStore ', action.type, ' FAILED action.res:', action.res);
-          return state;
-        }
-        revisedState = state;
-        // if (action.res.teamId >= 0) {
-        //   teamId = action.res.teamId;
-        // } else {
-        //   teamId = -1;
-        // }
-
-        // console.log('PersonStore ', action.type, ' start action.res:', action.res);
-        if (action.res) {
-          personTemp = action.res;
-          // console.log('PersonStore add-person-to-team:', personTemp);
-          // Only add to allPeopleCache if they aren't already in the dictionary, since the person data that comes back with this API response is partial data
-          if (personTemp && (personTemp.personId >= 0) && !arrayContains(personTemp.personId, allPeopleCache)) {
-            allPeopleCache[personTemp.personId] = personTemp;
-          }
-          // console.log('allPeopleCache:', allPeopleCache);
-          revisedState = {
-            ...revisedState,
-            allPeopleCache,
-          };
-        }
-        return revisedState;
-
-      case 'person-list-retrieve':
-        if (!action.res.success) {
-          console.log('PersonStore ', action.type, ' FAILED action.res:', action.res);
-          return state;
-        }
-        revisedState = state;
-        // console.log('PersonStore person-list-retrieve personList:', action.res.personList);
-        if (action.res.isSearching && action.res.isSearching === true) {
-          // console.log('PersonStore isSearching:', action.res.isSearching);
-          searchResults = action.res.personList;
-          // console.log('PersonStore searchResults:', searchResults);
-          revisedState = {
-            ...revisedState,
-            searchResults,
-          };
-        }
-        if (action.res.personList) {
-          action.res.personList.forEach((person) => {
-            // console.log('PersonStore team-retrieve adding person:', person);
-            if (person && (person.id >= 0)) {
-              allPeopleCache[person.id] = person;
-            }
-          });
-          // console.log('allPeopleCache:', allPeopleCache);
-          revisedState = {
-            ...revisedState,
-            allPeopleCache,
-          };
-        }
-        // console.log('PersonStore revisedState:', revisedState);
-        return revisedState;
-
-      case 'person-retrieve':
-        if (!action.res.success) {
-          console.log('PersonStore ', action.type, ' FAILED action.res:', action.res);
-          return state;
-        }
-        revisedState = state;
-        if (action.res.personId >= 0) {
-          personId = action.res.personId;
-        } else {
-          personId = -1;
-        }
-
-        if (personId >= 0) {
-          // console.log('PersonStore person-save personId:', personId);
-          allPeopleCache[personId] = action.res;
-          revisedState = {
-            ...revisedState,
-            allPeopleCache,
-          };
-        } else {
-          console.log('PersonStore person-retrieve MISSING personId:', personId);
-        }
-        return revisedState;
-
-      case 'person-save':
-        if (!action.res.success) {
-          console.log('PersonStore ', action.type, ' FAILED action.res:', action.res);
-          return state;
-        }
-        revisedState = state;
-        if (action.res.personId >= 0) {
-          personId = action.res.personId;
-        } else {
-          personId = -1;
-        }
-
-        if (personId >= 0) {
-          // console.log('PersonStore person-save personId:', personId);
-          allPeopleCache[personId] = action.res;
-          revisedState = {
-            ...revisedState,
-            allPeopleCache,
-            mostRecentPersonIdSaved: personId,
-          };
-        } else {
-          console.log('PersonStore person-save MISSING personId:', personId);
-        }
-        return revisedState;
-
-      case 'team-list-retrieve':
-        if (!action.res.success) {
-          console.log('TeamStore ', action.type, ' FAILED action.res:', action.res);
-          return state;
-        }
-        teamList = action.res.teamList || [];
-        revisedState = state;
-        teamList.forEach((team) => {
-          if (team && (team.id >= 0)) {
-            if (team.teamMemberList) {
-              teamMemberList = team.teamMemberList || [];
-              teamMemberList.forEach((person) => {
-                // console.log('PersonStore team-retrieve adding person:', person);
-                if (person && (person.id >= 0) && !arrayContains(person.id, allPeopleCache)) {
-                  allPeopleCache[person.id] = person;
-                }
-              });
-            }
-          }
-        });
-
-        revisedState = {
-          ...revisedState,
-          allPeopleCache,
-        };
-        return revisedState;
-
-      case 'team-retrieve':
-      case 'team-save':
-        if (!action.res.success) {
-          console.log('PersonStore ', action.type, ' FAILED action.res:', action.res);
-          return state;
-        }
-        revisedState = state;
-        if (action.res.teamId >= 0) {
-          teamId = action.res.teamId;
-        } else {
-          teamId = -1;
-        }
-
-        // console.log('PersonStore ', action.type, ' start allPeopleCache:', allPeopleCache);
-        if (teamId >= 0 && action.res.teamMemberList) {
-          teamMemberList = action.res.teamMemberList || [];
-          teamMemberList.forEach((person) => {
-            // console.log('PersonStore team-retrieve adding person:', person);
-            if (person && (person.id >= 0) && !arrayContains(person.id, allPeopleCache)) {
-              allPeopleCache[person.id] = person;
-            }
-          });
-          // console.log('allPeopleCache:', allPeopleCache);
-          revisedState = {
-            ...revisedState,
-            allPeopleCache,
-          };
-        }
-        return revisedState;
-
-      default:
-        return state;
-    }
-  }
-}
-
-export default new PersonStore(Dispatcher);
+// import { ReduceStore } from 'flux/utils';
+// import Dispatcher from '../common/dispatcher/Dispatcher';
+// import Cookies from '../common/utils/js-cookie/Cookies';
+// import arrayContains from '../common/utils/arrayContains';
+//
+// class PersonStore extends ReduceStore {
+//   getInitialState () {
+//     return {
+//       allPeopleCache: {}, // This is a dictionary key: personId, value: person dict
+//       mostRecentPersonIdSaved: -1,
+//       mostRecentPersonSaved: {
+//         firstName: '',
+//         lastName: '',
+//         personId: '',
+//       },
+//       searchResults: [],
+//     };
+//   }
+//
+//   getAllCachedPeopleList () {
+//     const { allPeopleCache } = this.getState();
+//     const personListRaw = Object.values(allPeopleCache);
+//
+//     const personList = [];
+//     let personFiltered;
+//     let personRaw;
+//     for (let i = 0; i < personListRaw.length; i++) {
+//       personRaw = personListRaw[i];
+//       // console.log('PersonStore getAllCachedPeopleList person:', person);
+//       personFiltered = personRaw;
+//       personList.push(personFiltered);
+//     }
+//     return personList;
+//   }
+//
+//   getFirstName (personId) {
+//     const person = this.getPersonById(personId);
+//     return person.firstName || '';
+//   }
+//
+//   getFullNamePreferred (personId) {
+//     const person = this.getPersonById(personId);
+//     let fullName = '';
+//     if (person.id >= 0) {
+//       if (person.firstNamePreferred) {
+//         fullName += person.firstNamePreferred;
+//       } else if (person.firstName) {
+//         fullName += person.firstName;
+//       }
+//       if (fullName.length > 0 && person.lastName) {
+//         fullName += ' ';
+//       }
+//       if (person.lastName) {
+//         fullName += person.lastName;
+//       }
+//     }
+//     return fullName;
+//   }
+//
+//   getFirstPlusLastName (personId) {
+//     const storedFirstName = this.getFirstName(personId);
+//     const storedLastName = this.getLastName(personId);
+//     let displayName = '';
+//     if (storedFirstName && String(storedFirstName) !== '') {
+//       displayName = storedFirstName;
+//       if (storedLastName && String(storedLastName) !== '') {
+//         displayName += ' ';
+//       }
+//     }
+//     if (storedLastName && String(storedLastName) !== '') {
+//       displayName += storedLastName;
+//     }
+//     return displayName;
+//   }
+//
+//   getLastName (personId) {
+//     const person = this.getPersonById(personId);
+//     return person.lastName || '';
+//   }
+//
+//   getMostRecentPersonChanged () {
+//     // console.log('PersonStore getMostRecentPersonChanged Id:', this.getState().mostRecentPersonIdSaved);
+//     if (this.getState().mostRecentPersonIdSaved !== -1) {
+//       return this.getPersonById(this.getState().mostRecentPersonIdSaved);
+//     }
+//     return {};
+//   }
+//
+//   getPersonById (personId) {
+//     const { allPeopleCache } = this.getState();
+//     // console.log('PersonStore getPersonById:', personId, ', allPeopleCache:', allPeopleCache);
+//     return allPeopleCache[personId] || {};
+//   }
+//
+//   getPersonDeviceId () {
+//     return this.getState().person.personDeviceId || Cookies.get('personDeviceId');
+//   }
+//
+//   getStateCode (personId) {
+//     const person = this.getPersonById(personId);
+//     return person.stateCode || '';
+//   }
+//
+//   getSearchResults () {
+//     // console.log('PersonStore getSearchResults:', this.getState().searchResults);
+//     return this.getState().searchResults || [];
+//   }
+//
+//   getSignedInPersonId () {
+//     // TODO: Implement this logic
+//   }
+//
+//   reduce (state, action) {
+//     const { allPeopleCache } = state;
+//     let personTemp = {};
+//     let personId = -1;
+//     let revisedState = state;
+//     let searchResults = [];
+//     let teamId = -1;
+//     let teamList = [];
+//     let teamMemberList = [];
+//
+//     switch (action.type) {
+//       case 'add-person-to-team':
+//         if (!action.res.success) {
+//           console.log('PersonStore ', action.type, ' FAILED action.res:', action.res);
+//           return state;
+//         }
+//         revisedState = state;
+//         // if (action.res.teamId >= 0) {
+//         //   teamId = action.res.teamId;
+//         // } else {
+//         //   teamId = -1;
+//         // }
+//
+//         // console.log('PersonStore ', action.type, ' start action.res:', action.res);
+//         if (action.res) {
+//           personTemp = action.res;
+//           // console.log('PersonStore add-person-to-team:', personTemp);
+//           // Only add to allPeopleCache if they aren't already in the dictionary, since the person data that comes back with this API response is partial data
+//           if (personTemp && (personTemp.personId >= 0) && !arrayContains(personTemp.personId, allPeopleCache)) {
+//             allPeopleCache[personTemp.personId] = personTemp;
+//           }
+//           // console.log('allPeopleCache:', allPeopleCache);
+//           revisedState = {
+//             ...revisedState,
+//             allPeopleCache,
+//           };
+//         }
+//         return revisedState;
+//
+//       case 'person-list-retrieve':
+//         if (!action.res.success) {
+//           console.log('PersonStore ', action.type, ' FAILED action.res:', action.res);
+//           return state;
+//         }
+//         revisedState = state;
+//         // console.log('PersonStore person-list-retrieve personList:', action.res.personList);
+//         if (action.res.isSearching && action.res.isSearching === true) {
+//           // console.log('PersonStore isSearching:', action.res.isSearching);
+//           searchResults = action.res.personList;
+//           // console.log('PersonStore searchResults:', searchResults);
+//           revisedState = {
+//             ...revisedState,
+//             searchResults,
+//           };
+//         }
+//         if (action.res.personList) {
+//           action.res.personList.forEach((person) => {
+//             // console.log('PersonStore team-retrieve adding person:', person);
+//             if (person && (person.id >= 0)) {
+//               allPeopleCache[person.id] = person;
+//             }
+//           });
+//           // console.log('allPeopleCache:', allPeopleCache);
+//           revisedState = {
+//             ...revisedState,
+//             allPeopleCache,
+//           };
+//         }
+//         // console.log('PersonStore revisedState:', revisedState);
+//         return revisedState;
+//
+//       case 'person-retrieve':
+//         if (!action.res.success) {
+//           console.log('PersonStore ', action.type, ' FAILED action.res:', action.res);
+//           return state;
+//         }
+//         revisedState = state;
+//         if (action.res.personId >= 0) {
+//           personId = action.res.personId;
+//         } else {
+//           personId = -1;
+//         }
+//
+//         if (personId >= 0) {
+//           // console.log('PersonStore person-save personId:', personId);
+//           allPeopleCache[personId] = action.res;
+//           revisedState = {
+//             ...revisedState,
+//             allPeopleCache,
+//           };
+//         } else {
+//           console.log('PersonStore person-retrieve MISSING personId:', personId);
+//         }
+//         return revisedState;
+//
+//       case 'person-save':
+//         if (!action.res.success) {
+//           console.log('PersonStore ', action.type, ' FAILED action.res:', action.res);
+//           return state;
+//         }
+//         revisedState = state;
+//         if (action.res.personId >= 0) {
+//           personId = action.res.personId;
+//         } else {
+//           personId = -1;
+//         }
+//
+//         if (personId >= 0) {
+//           // console.log('PersonStore person-save personId:', personId);
+//           allPeopleCache[personId] = action.res;
+//           revisedState = {
+//             ...revisedState,
+//             allPeopleCache,
+//             mostRecentPersonIdSaved: personId,
+//           };
+//         } else {
+//           console.log('PersonStore person-save MISSING personId:', personId);
+//         }
+//         return revisedState;
+//
+//       case 'team-list-retrieve':
+//         if (!action.res.success) {
+//           console.log('TeamStore ', action.type, ' FAILED action.res:', action.res);
+//           return state;
+//         }
+//         teamList = action.res.teamList || [];
+//         revisedState = state;
+//         teamList.forEach((team) => {
+//           if (team && (team.id >= 0)) {
+//             if (team.teamMemberList) {
+//               teamMemberList = team.teamMemberList || [];
+//               teamMemberList.forEach((person) => {
+//                 // console.log('PersonStore team-retrieve adding person:', person);
+//                 if (person && (person.id >= 0) && !arrayContains(person.id, allPeopleCache)) {
+//                   allPeopleCache[person.id] = person;
+//                 }
+//               });
+//             }
+//           }
+//         });
+//
+//         revisedState = {
+//           ...revisedState,
+//           allPeopleCache,
+//         };
+//         return revisedState;
+//
+//       case 'team-retrieve':
+//       case 'team-save':
+//         if (!action.res.success) {
+//           console.log('PersonStore ', action.type, ' FAILED action.res:', action.res);
+//           return state;
+//         }
+//         revisedState = state;
+//         if (action.res.teamId >= 0) {
+//           teamId = action.res.teamId;
+//         } else {
+//           teamId = -1;
+//         }
+//
+//         // console.log('PersonStore ', action.type, ' start allPeopleCache:', allPeopleCache);
+//         if (teamId >= 0 && action.res.teamMemberList) {
+//           teamMemberList = action.res.teamMemberList || [];
+//           teamMemberList.forEach((person) => {
+//             // console.log('PersonStore team-retrieve adding person:', person);
+//             if (person && (person.id >= 0) && !arrayContains(person.id, allPeopleCache)) {
+//               allPeopleCache[person.id] = person;
+//             }
+//           });
+//           // console.log('allPeopleCache:', allPeopleCache);
+//           revisedState = {
+//             ...revisedState,
+//             allPeopleCache,
+//           };
+//         }
+//         return revisedState;
+//
+//       default:
+//         return state;
+//     }
+//   }
+// }
+//
+// export default new PersonStore(Dispatcher);

--- a/src/js/stores/TaskStore.js
+++ b/src/js/stores/TaskStore.js
@@ -1,352 +1,704 @@
-import { ReduceStore } from 'flux/utils';
-import Dispatcher from '../common/dispatcher/Dispatcher';
-
-class TaskStore extends ReduceStore {
-  getInitialState () {
-    return {
-      allTaskGroupsCache: {}, // This is a dictionary key: taskGroupId, value: TaskGroup dict
-      allTaskDefinitionsCache: {}, // This is a dictionary key: taskDefinitionId, value: TaskDefinition dict
-      allTaskDependenciesCache: {}, // This is a dictionary key: taskDependencyId, value: TaskDependency dict
-      allTasksCache: {}, // This is a dictionary key: personId, value: another dictionary key: taskDefinitionId, value: Task dict
-      mostRecentTaskDefinitionIdSaved: -1,
-      mostRecentTaskDefinitionSaved: {
-        taskDefinitionId: -1,
-      },
-      mostRecentTaskGroupIdSaved: -1,
-      mostRecentTaskGroupSaved: {
-        firstName: '',
-        lastName: '',
-        taskDefinitionId: -1,
-      },
-      taskDefinitionsCompletedPersonIdList: {}, // This is a dictionary key: taskDefinitionId, value: list of personIds who have completed the TaskDefinition
-      taskGroupCompletedByPersonList: {}, // This is a dictionary key: taskGroupId, value: list of personIds who have completed the TaskGroup
-      searchResults: [],
-    };
-  }
-
-  getAllCachedTaskDefinitionsList () {
-    const { allTaskDefinitionsCache } = this.getState();
-    const taskDefinitionListRaw = Object.values(allTaskDefinitionsCache);
-
-    const taskDefinitionList = [];
-    let taskDefinitionFiltered;
-    let taskDefinitionRaw;
-    for (let i = 0; i < taskDefinitionListRaw.length; i++) {
-      taskDefinitionRaw = taskDefinitionListRaw[i];
-      // console.log('TaskStore getAllCachedTaskDefinitionsList taskDefinition:', taskDefinition);
-      taskDefinitionFiltered = taskDefinitionRaw;
-      taskDefinitionList.push(taskDefinitionFiltered);
-    }
-    return taskDefinitionList;
-  }
-
-  getAllCachedTaskGroupList () {
-    const { allTaskGroupsCache } = this.getState();
-    const taskGroupListRaw = Object.values(allTaskGroupsCache);
-
-    const taskGroupList = [];
-    let taskGroupFiltered;
-    let taskGroupRaw;
-    for (let i = 0; i < taskGroupListRaw.length; i++) {
-      taskGroupRaw = taskGroupListRaw[i];
-      // console.log('TaskStore getAllCachedTaskDefinitionsList taskGroup:', taskGroup);
-      taskGroupFiltered = taskGroupRaw;
-      taskGroupList.push(taskGroupFiltered);
-    }
-    return taskGroupList;
-  }
-
-  getMostRecentTaskGroupChanged () {
-    // console.log('TaskStore getMostRecentTaskGroupChanged Id:', this.getState().mostRecentTaskGroupIdSaved);
-    if (this.getState().mostRecentTaskGroupIdSaved !== -1) {
-      return this.getTaskGroupById(this.getState().mostRecentTaskGroupIdSaved);
-    }
-    return {};
-  }
-
-  getMostRecentTaskGroupIdChanged () {
-    // console.log('TaskStore getMostRecentTaskGroupChanged Id:', this.getState().mostRecentTaskGroupIdSaved);
-    return this.getState().mostRecentTaskGroupIdSaved;
-  }
-
-  getTask (personId, taskDefinitionId) {
-    const { allTasksCache } = this.getState();
-    // console.log('TaskStore getTaskListDictByPersonId:', personId, ', allTasksCache:', allTasksCache);
-    return allTasksCache[personId][taskDefinitionId] || {};
-  }
-
-  getTaskDefinitionListByTaskGroupId (taskGroupId) {
-    const { allTaskDefinitionsCache } = this.getState();
-    const taskDefinitionListRaw = Object.values(allTaskDefinitionsCache);
-    const taskDefinitionListForTaskDefinition = [];
-    for (let i = 0; i < taskDefinitionListRaw.length; i++) {
-      if (taskDefinitionListRaw[i].taskGroupId === taskGroupId) {
-        taskDefinitionListForTaskDefinition.push(taskDefinitionListRaw[i]);
-      }
-    }
-    // console.log('TaskStore getTaskDefinitionById:', taskDefinitionId, ', taskDefinitionListForTaskDefinition:', taskDefinitionListForTaskDefinition);
-    return taskDefinitionListForTaskDefinition;
-  }
-
-  getTaskGroupById (taskGroupId) {
-    const { allTaskGroupsCache } = this.getState();
-    // console.log('TaskStore getTaskGroupById:', taskGroupId, ', allTaskGroupsCache:', allTaskGroupsCache);
-    return allTaskGroupsCache[taskGroupId] || {};
-  }
-
-  getTaskGroupIdByTaskDefinitionId (taskDefinitionId) {
-    const taskDefinitionDict = this.getTaskDefinitionById(taskDefinitionId);
-    return taskDefinitionDict.taskGroupId || -1;
-  }
-
-  getTaskDefinitionById (taskDefinitionId) {
-    const { allTaskDefinitionsCache } = this.getState();
-    // console.log('TaskStore getTaskDefinitionById:', taskDefinitionId, ', allTaskDefinitionsCache:', allTaskDefinitionsCache);
-    return allTaskDefinitionsCache[taskDefinitionId] || {};
-  }
-
-  getTaskListDictByPersonId (personId) {
-    const { allTasksCache } = this.getState();
-    // console.log('TaskStore getTaskListDictByPersonId:', personId, ', allTasksCache:', allTasksCache);
-    return allTasksCache[personId] || {};
-  }
-
-  getTaskListForPerson (personId) {
-    const taskDict = this.getTaskListDictByPersonId(personId);
-    const taskList = Object.values(taskDict);
-    // console.log('TaskStore getTasksCompletedByPersonList:', personId, ', taskDefinitionsCompletedPersonIdList:', taskDefinitionsCompletedPersonIdList);
-    return taskList || [];
-  }
-
-  getSearchResults () {
-    // console.log('TaskStore getSearchResults:', this.getState().searchResults);
-    return this.getState().searchResults || [];
-  }
-
-  reduce (state, action) {
-    const {
-      allTaskGroupsCache, allTaskDefinitionsCache, allTasksCache,
-    } = state;
-    let missingRequiredVariable = false;
-    let personId = -1;
-    let taskDefinitionId = -1;
-    let revisedState = state;
-    let searchResults = [];
-    let taskGroupId = -1;
-
-    switch (action.type) {
-      case 'task-definition-list-retrieve':
-        if (!action.res.success) {
-          console.log('TaskStore ', action.type, ' FAILED action.res:', action.res);
-          return state;
-        }
-        revisedState = state;
-        // console.log('TaskStore task-definition-list-retrieve taskDefinitionList:', action.res.taskDefinitionList);
-        if (action.res.isSearching && action.res.isSearching === true) {
-          // console.log('TaskStore isSearching:', action.res.isSearching);
-          searchResults = action.res.taskDefinitionList;
-          // console.log('TaskStore searchResults:', searchResults);
-          revisedState = {
-            ...revisedState,
-            searchResults,
-          };
-        }
-        if (action.res.taskDefinitionList) {
-          action.res.taskDefinitionList.forEach((taskDefinition) => {
-            // console.log('TaskStore task-definition-list-retrieve adding taskDefinition:', taskDefinition);
-            if (taskDefinition && (taskDefinition.id >= 0)) {
-              allTaskDefinitionsCache[taskDefinition.id] = taskDefinition;
-            }
-          });
-          // console.log('allTaskDefinitionsCache:', allTaskDefinitionsCache);
-          revisedState = {
-            ...revisedState,
-            allTaskDefinitionsCache,
-          };
-        }
-        // console.log('TaskStore revisedState:', revisedState);
-        return revisedState;
-
-      case 'task-definition-save':
-        if (!action.res.success) {
-          console.log('TaskStore ', action.type, ' FAILED action.res:', action.res);
-          return state;
-        }
-        revisedState = state;
-        if (action.res.taskDefinitionId >= 0) {
-          taskDefinitionId = action.res.taskDefinitionId;
-        } else {
-          taskDefinitionId = -1;
-        }
-
-        if (taskDefinitionId >= 0) {
-          if (action.res.taskDefinitionCreated || action.res.taskDefinitionUpdated) {
-            // console.log('TaskStore taskDefinition-save taskDefinitionId:', taskDefinitionId);
-            allTaskDefinitionsCache[taskDefinitionId] = action.res;
-            revisedState = {
-              ...revisedState,
-              allTaskDefinitionsCache,
-              mostRecentTaskDefinitionIdSaved: taskDefinitionId,
-            };
-          } else {
-            console.log('TaskStore task-definition-save NOT updated or saved.');
-          }
-        } else {
-          console.log('TaskStore task-definition-save MISSING taskDefinitionId:', taskDefinitionId);
-        }
-        return revisedState;
-
-      case 'task-group-list-retrieve':
-        if (!action.res.success) {
-          console.log('TaskStore ', action.type, ' FAILED action.res:', action.res);
-          return state;
-        }
-        revisedState = state;
-        // console.log('TaskStore task-group-list-retrieve taskGroupList:', action.res.taskGroupList);
-        if (action.res.isSearching && action.res.isSearching === true) {
-          // console.log('TaskStore isSearching:', action.res.isSearching);
-          searchResults = action.res.taskGroupList;
-          // console.log('TaskStore searchResults:', searchResults);
-          revisedState = {
-            ...revisedState,
-            searchResults,
-          };
-        }
-        if (action.res.taskGroupList) {
-          action.res.taskGroupList.forEach((taskGroup) => {
-            // console.log('TaskStore task-group-list-retrieve adding taskGroup:', taskGroup);
-            if (taskGroup && (taskGroup.id >= 0)) {
-              allTaskGroupsCache[taskGroup.id] = taskGroup;
-            }
-          });
-          // console.log('allTaskGroupsCache:', allTaskGroupsCache);
-          revisedState = {
-            ...revisedState,
-            allTaskGroupsCache,
-          };
-        }
-        // console.log('TaskStore revisedState:', revisedState);
-        return revisedState;
-
-      case 'task-group-save':
-        if (!action.res.success) {
-          console.log('TaskStore ', action.type, ' FAILED action.res:', action.res);
-          return state;
-        }
-        revisedState = state;
-        if (action.res.taskGroupId >= 0) {
-          taskGroupId = action.res.taskGroupId;
-        } else {
-          taskGroupId = -1;
-        }
-
-        if (taskGroupId >= 0) {
-          // console.log('TaskStore task-group-save taskGroupId:', taskGroupId);
-          allTaskGroupsCache[taskGroupId] = action.res;
-          revisedState = {
-            ...revisedState,
-            allTaskGroupsCache,
-            mostRecentTaskGroupIdSaved: taskGroupId,
-          };
-        } else {
-          console.log('TaskStore task-group-save MISSING taskGroupId:', taskGroupId);
-        }
-        return revisedState;
-
-      case 'task-save':
-        if (!action.res.success) {
-          console.log('TaskStore ', action.type, ' FAILED action.res:', action.res);
-          return state;
-        }
-        missingRequiredVariable = false;
-        revisedState = state;
-        if (action.res.personId >= 0) {
-          personId = action.res.personId;
-        } else {
-          personId = -1;
-          missingRequiredVariable = true;
-        }
-        if (action.res.taskDefinitionId >= 0) {
-          taskDefinitionId = action.res.taskDefinitionId;
-        } else {
-          taskDefinitionId = -1;
-          missingRequiredVariable = true;
-        }
-
-        if (!missingRequiredVariable) {
-          // console.log('TaskStore task-save personId:', personId, ', taskDefinitionId:', taskDefinitionId);
-          allTasksCache[personId][taskDefinitionId] = action.res;
-          revisedState = {
-            ...revisedState,
-            allTasksCache,
-          };
-        } else {
-          console.log('TaskStore task-save MISSING_REQUIRED_VARIABLE personId:', personId, ', taskDefinitionId:', taskDefinitionId);
-        }
-        return revisedState;
-
-      case 'task-status-list-retrieve':
-        if (!action.res.success) {
-          console.log('TaskStore ', action.type, ' FAILED action.res:', action.res);
-          return state;
-        }
-        revisedState = state;
-        // console.log('TaskStore task-definition-list-retrieve taskDefinitionList:', action.res.taskDefinitionList);
-        if (action.res.taskDefinitionList) {
-          action.res.taskDefinitionList.forEach((taskDefinition) => {
-            // console.log('TaskStore task-definition-list-retrieve adding taskDefinition:', taskDefinition);
-            if (taskDefinition && (taskDefinition.id >= 0)) {
-              allTaskDefinitionsCache[taskDefinition.id] = taskDefinition;
-            }
-          });
-          // console.log('allTaskDefinitionsCache:', allTaskDefinitionsCache);
-          revisedState = {
-            ...revisedState,
-            allTaskDefinitionsCache,
-          };
-        }
-        if (action.res.taskGroupList) {
-          action.res.taskGroupList.forEach((taskGroup) => {
-            // console.log('TaskStore task-group-list-retrieve adding taskGroup:', taskGroup);
-            if (taskGroup && (taskGroup.id >= 0)) {
-              allTaskGroupsCache[taskGroup.id] = taskGroup;
-            }
-          });
-          // console.log('allTaskGroupsCache:', allTaskGroupsCache);
-          revisedState = {
-            ...revisedState,
-            allTaskGroupsCache,
-          };
-        }
-        if (action.res.taskList) {
-          action.res.taskList.forEach((task) => {
-            // console.log('TaskStore task-group-list-retrieve adding taskGroup:', taskGroup);
-            if (task && (task.personId >= 0)) {
-              if (!allTasksCache[task.personId]) {
-                allTasksCache[task.personId] = {};
-              }
-              if (task && (task.taskDefinitionId >= 0)) {
-                allTasksCache[task.personId][task.taskDefinitionId] = task;
-              } else {
-                console.log('TaskStore task-group-list-retrieve skipping task with missing personId:', task);
-              }
-            } else {
-              console.log('TaskStore task-group-list-retrieve skipping task with missing taskDefinitionId:', task);
-            }
-          });
-          // console.log('allTasksCache:', allTasksCache);
-          revisedState = {
-            ...revisedState,
-            allTasksCache,
-          };
-        }
-        // console.log('TaskStore revisedState:', revisedState);
-        return revisedState;
-
-      default:
-        return state;
-    }
-  }
-}
-
-export default new TaskStore(Dispatcher);
+// import { ReduceStore } from 'flux/utils';
+// import Dispatcher from '../common/dispatcher/Dispatcher';
+//
+// class TaskStore extends ReduceStore {
+//   getInitialState () {
+//     return {
+//       allTaskGroupsCache: {}, // This is a dictionary key: taskGroupId, value: TaskGroup dict
+//       allTaskDefinitionsCache: {}, // This is a dictionary key: taskDefinitionId, value: TaskDefinition dict
+//       allTaskDependenciesCache: {}, // This is a dictionary key: taskDependencyId, value: TaskDependency dict
+//       allTasksCache: {}, // This is a dictionary key: personId, value: another dictionary key: taskDefinitionId, value: Task dict
+//       mostRecentTaskDefinitionIdSaved: -1,
+//       mostRecentTaskDefinitionSaved: {
+//         taskDefinitionId: -1,
+//       },
+//       mostRecentTaskGroupIdSaved: -1,
+//       mostRecentTaskGroupSaved: {
+//         firstName: '',
+//         lastName: '',
+//         taskDefinitionId: -1,
+//       },
+//       taskDefinitionsCompletedPersonIdList: {}, // This is a dictionary key: taskDefinitionId, value: list of personIds who have completed the TaskDefinition
+//       taskGroupCompletedByPersonList: {}, // This is a dictionary key: taskGroupId, value: list of personIds who have completed the TaskGroup
+//       searchResults: [],
+//     };
+//   }
+//
+//   getAllCachedTaskDefinitionsList () {
+//     const { allTaskDefinitionsCache } = this.getState();
+//     const taskDefinitionListRaw = Object.values(allTaskDefinitionsCache);
+//
+//     const taskDefinitionList = [];
+//     let taskDefinitionFiltered;
+//     let taskDefinitionRaw;
+//     for (let i = 0; i < taskDefinitionListRaw.length; i++) {
+//       taskDefinitionRaw = taskDefinitionListRaw[i];
+//       // console.log('TaskStore getAllCachedTaskDefinitionsList taskDefinition:', taskDefinition);
+//       taskDefinitionFiltered = taskDefinitionRaw;
+//       taskDefinitionList.push(taskDefinitionFiltered);
+//     }
+//     return taskDefinitionList;
+//   }
+//
+//   getAllCachedTaskGroupList () {
+//     const { allTaskGroupsCache } = this.getState();
+//     const taskGroupListRaw = Object.values(allTaskGroupsCache);
+//
+//     const taskGroupList = [];
+//     let taskGroupFiltered;
+//     let taskGroupRaw;
+//     for (let i = 0; i < taskGroupListRaw.length; i++) {
+//       taskGroupRaw = taskGroupListRaw[i];
+//       // console.log('TaskStore getAllCachedTaskDefinitionsList taskGroup:', taskGroup);
+//       taskGroupFiltered = taskGroupRaw;
+//       taskGroupList.push(taskGroupFiltered);
+//     }
+//     return taskGroupList;
+//   }
+//
+//   getMostRecentTaskGroupChanged () {
+//     // console.log('TaskStore getMostRecentTaskGroupChanged Id:', this.getState().mostRecentTaskGroupIdSaved);
+//     if (this.getState().mostRecentTaskGroupIdSaved !== -1) {
+//       return this.getTaskGroupById(this.getState().mostRecentTaskGroupIdSaved);
+//     }
+//     return {};
+//   }
+//
+//   getMostRecentTaskGroupIdChanged () {
+//     // console.log('TaskStore getMostRecentTaskGroupChanged Id:', this.getState().mostRecentTaskGroupIdSaved);
+//     return this.getState().mostRecentTaskGroupIdSaved;
+//   }
+//
+//   getTask (personId, taskDefinitionId) {
+//     const { allTasksCache } = this.getState();
+//     // console.log('TaskStore getTaskListDictByPersonId:', personId, ', allTasksCache:', allTasksCache);
+//     return allTasksCache[personId][taskDefinitionId] || {};
+//   }
+//
+//   getTaskDefinitionListByTaskGroupId (taskGroupId) {
+//     const { allTaskDefinitionsCache } = this.getState();
+//     const taskDefinitionListRaw = Object.values(allTaskDefinitionsCache);
+//     const taskDefinitionListForTaskDefinition = [];
+//     for (let i = 0; i < taskDefinitionListRaw.length; i++) {
+//       if (taskDefinitionListRaw[i].taskGroupId === taskGroupId) {
+//         taskDefinitionListForTaskDefinition.push(taskDefinitionListRaw[i]);
+//       }
+//     }
+//     // console.log('TaskStore getTaskDefinitionById:', taskDefinitionId, ', taskDefinitionListForTaskDefinition:', taskDefinitionListForTaskDefinition);
+//     return taskDefinitionListForTaskDefinition;
+//   }
+//
+//   getTaskGroupById (taskGroupId) {
+//     const { allTaskGroupsCache } = this.getState();
+//     // console.log('TaskStore getTaskGroupById:', taskGroupId, ', allTaskGroupsCache:', allTaskGroupsCache);
+//     return allTaskGroupsCache[taskGroupId] || {};
+//   }
+//
+//   getTaskGroupIdByTaskDefinitionId (taskDefinitionId) {
+//     const taskDefinitionDict = this.getTaskDefinitionById(taskDefinitionId);
+//     return taskDefinitionDict.taskGroupId || -1;
+//   }
+//
+//   getTaskDefinitionById (taskDefinitionId) {
+//     const { allTaskDefinitionsCache } = this.getState();
+//     // console.log('TaskStore getTaskDefinitionById:', taskDefinitionId, ', allTaskDefinitionsCache:', allTaskDefinitionsCache);
+//     return allTaskDefinitionsCache[taskDefinitionId] || {};
+//   }
+//
+//   getTaskListDictByPersonId (personId) {
+//     const { allTasksCache } = this.getState();
+//     // console.log('TaskStore getTaskListDictByPersonId:', personId, ', allTasksCache:', allTasksCache);
+//     return allTasksCache[personId] || {};
+//   }
+//
+//   getTaskListForPerson (personId) {
+//     const taskDict = this.getTaskListDictByPersonId(personId);
+//     const taskList = Object.values(taskDict);
+//     // console.log('TaskStore getTasksCompletedByPersonList:', personId, ', taskDefinitionsCompletedPersonIdList:', taskDefinitionsCompletedPersonIdList);
+//     return taskList || [];
+//   }
+//
+//   getSearchResults () {
+//     // console.log('TaskStore getSearchResults:', this.getState().searchResults);
+//     return this.getState().searchResults || [];
+//   }
+//
+//   reduce (state, action) {
+//     const {
+//       allTaskGroupsCache, allTaskDefinitionsCache, allTasksCache,
+//     } = state;
+//     let missingRequiredVariable = false;
+//     let personId = -1;
+//     let taskDefinitionId = -1;
+//     let revisedState = state;
+//     let searchResults = [];
+//     let taskGroupId = -1;
+//
+//     switch (action.type) {
+//       case 'task-definition-list-retrieve':
+//         if (!action.res.success) {
+//           console.log('TaskStore ', action.type, ' FAILED action.res:', action.res);
+//           return state;
+//         }
+//         revisedState = state;
+//         // console.log('TaskStore task-definition-list-retrieve taskDefinitionList:', action.res.taskDefinitionList);
+//         if (action.res.isSearching && action.res.isSearching === true) {
+//           // console.log('TaskStore isSearching:', action.res.isSearching);
+//           searchResults = action.res.taskDefinitionList;
+//           // console.log('TaskStore searchResults:', searchResults);
+//           revisedState = {
+//             ...revisedState,
+//             searchResults,
+//           };
+//         }
+//         if (action.res.taskDefinitionList) {
+//           action.res.taskDefinitionList.forEach((taskDefinition) => {
+//             // console.log('TaskStore task-definition-list-retrieve adding taskDefinition:', taskDefinition);
+//             if (taskDefinition && (taskDefinition.id >= 0)) {
+//               allTaskDefinitionsCache[taskDefinition.id] = taskDefinition;
+//             }
+//           });
+//           // console.log('allTaskDefinitionsCache:', allTaskDefinitionsCache);
+//           revisedState = {
+//             ...revisedState,
+//             allTaskDefinitionsCache,
+//           };
+//         }
+//         // console.log('TaskStore revisedState:', revisedState);
+//         return revisedState;
+//
+//       case 'task-definition-save':
+//         if (!action.res.success) {
+//           console.log('TaskStore ', action.type, ' FAILED action.res:', action.res);
+//           return state;
+//         }
+//         revisedState = state;
+//         if (action.res.taskDefinitionId >= 0) {
+//           taskDefinitionId = action.res.taskDefinitionId;
+//         } else {
+//           taskDefinitionId = -1;
+//         }
+//
+//         if (taskDefinitionId >= 0) {
+//           if (action.res.taskDefinitionCreated || action.res.taskDefinitionUpdated) {
+//             // console.log('TaskStore taskDefinition-save taskDefinitionId:', taskDefinitionId);
+//             allTaskDefinitionsCache[taskDefinitionId] = action.res;
+//             revisedState = {
+//               ...revisedState,
+//               allTaskDefinitionsCache,
+//               mostRecentTaskDefinitionIdSaved: taskDefinitionId,
+//             };
+//           } else {
+//             console.log('TaskStore task-definition-save NOT updated or saved.');
+//           }
+//         } else {
+//           console.log('TaskStore task-definition-save MISSING taskDefinitionId:', taskDefinitionId);
+//         }
+//         return revisedState;
+//
+//       case 'task-group-list-retrieve':
+//         if (!action.res.success) {
+//           console.log('TaskStore ', action.type, ' FAILED action.res:', action.res);
+//           return state;
+//         }
+//         revisedState = state;
+//         // console.log('TaskStore task-group-list-retrieve taskGroupList:', action.res.taskGroupList);
+//         if (action.res.isSearching && action.res.isSearching === true) {
+//           // console.log('TaskStore isSearching:', action.res.isSearching);
+//           searchResults = action.res.taskGroupList;
+//           // console.log('TaskStore searchResults:', searchResults);
+//           revisedState = {
+//             ...revisedState,
+//             searchResults,
+//           };
+//         }
+//         if (action.res.taskGroupList) {
+//           action.res.taskGroupList.forEach((taskGroup) => {
+//             // console.log('TaskStore task-group-list-retrieve adding taskGroup:', taskGroup);
+//             if (taskGroup && (taskGroup.id >= 0)) {
+//               allTaskGroupsCache[taskGroup.id] = taskGroup;
+//             }
+//           });
+//           // console.log('allTaskGroupsCache:', allTaskGroupsCache);
+//           revisedState = {
+//             ...revisedState,
+//             allTaskGroupsCache,
+//           };
+//         }
+//         // console.log('TaskStore revisedState:', revisedState);
+//         return revisedState;
+//
+//       case 'task-group-save':
+//         if (!action.res.success) {
+//           console.log('TaskStore ', action.type, ' FAILED action.res:', action.res);
+//           return state;
+//         }
+//         revisedState = state;
+//         if (action.res.taskGroupId >= 0) {
+//           taskGroupId = action.res.taskGroupId;
+//         } else {
+//           taskGroupId = -1;
+//         }
+//
+//         if (taskGroupId >= 0) {
+//           // console.log('TaskStore task-group-save taskGroupId:', taskGroupId);
+//           allTaskGroupsCache[taskGroupId] = action.res;
+//           revisedState = {
+//             ...revisedState,
+//             allTaskGroupsCache,
+//             mostRecentTaskGroupIdSaved: taskGroupId,
+//           };
+//         } else {
+//           console.log('TaskStore task-group-save MISSING taskGroupId:', taskGroupId);
+//         }
+//         return revisedState;
+//
+//       case 'task-save':
+//         if (!action.res.success) {
+//           console.log('TaskStore ', action.type, ' FAILED action.res:', action.res);
+//           return state;
+//         }
+//         missingRequiredVariable = false;
+//         revisedState = state;
+//         if (action.res.personId >= 0) {
+//           personId = action.res.personId;
+//         } else {
+//           personId = -1;
+//           missingRequiredVariable = true;
+//         }
+//         if (action.res.taskDefinitionId >= 0) {
+//           taskDefinitionId = action.res.taskDefinitionId;
+//         } else {
+//           taskDefinitionId = -1;
+//           missingRequiredVariable = true;
+//         }
+//
+//         if (!missingRequiredVariable) {
+//           // console.log('TaskStore task-save personId:', personId, ', taskDefinitionId:', taskDefinitionId);
+//           allTasksCache[personId][taskDefinitionId] = action.res;
+//           revisedState = {
+//             ...revisedState,
+//             allTasksCache,
+//           };
+//         } else {
+//           console.log('TaskStore task-save MISSING_REQUIRED_VARIABLE personId:', personId, ', taskDefinitionId:', taskDefinitionId);
+//         }
+//         return revisedState;
+//
+//       case 'task-status-list-retrieve':
+//         if (!action.res.success) {
+//           console.log('TaskStore ', action.type, ' FAILED action.res:', action.res);
+//           return state;
+//         }
+//         revisedState = state;
+//         // console.log('TaskStore task-definition-list-retrieve taskDefinitionList:', action.res.taskDefinitionList);
+//         if (action.res.taskDefinitionList) {
+//           action.res.taskDefinitionList.forEach((taskDefinition) => {
+//             // console.log('TaskStore task-definition-list-retrieve adding taskDefinition:', taskDefinition);
+//             if (taskDefinition && (taskDefinition.id >= 0)) {
+//               allTaskDefinitionsCache[taskDefinition.id] = taskDefinition;
+//             }
+//           });
+//           // console.log('allTaskDefinitionsCache:', allTaskDefinitionsCache);
+//           revisedState = {
+//             ...revisedState,
+//             allTaskDefinitionsCache,
+//           };
+//         }
+//         if (action.res.taskGroupList) {
+//           action.res.taskGroupList.forEach((taskGroup) => {
+//             // console.log('TaskStore task-group-list-retrieve adding taskGroup:', taskGroup);
+//             if (taskGroup && (taskGroup.id >= 0)) {
+//               allTaskGroupsCache[taskGroup.id] = taskGroup;
+//             }
+//           });
+//           // console.log('allTaskGroupsCache:', allTaskGroupsCache);
+//           revisedState = {
+//             ...revisedState,
+//             allTaskGroupsCache,
+//           };
+//         }
+//         if (action.res.taskList) {
+//           action.res.taskList.forEach((task) => {
+//             // console.log('TaskStore task-group-list-retrieve adding taskGroup:', taskGroup);
+//             if (task && (task.personId >= 0)) {
+//               if (!allTasksCache[task.personId]) {
+//                 allTasksCache[task.personId] = {};
+//               }
+//               if (task && (task.taskDefinitionId >= 0)) {
+//                 allTasksCache[task.personId][task.taskDefinitionId] = task;
+//               } else {
+//                 console.log('TaskStore task-group-list-retrieve skipping task with missing personId:', task);
+//               }
+//             } else {
+//               console.log('TaskStore task-group-list-retrieve skipping task with missing taskDefinitionId:', task);
+//             }
+//           });
+//           // console.log('allTasksCache:', allTasksCache);
+//           revisedState = {
+//             ...revisedState,
+//             allTasksCache,
+//           };
+//         }
+//         // console.log('TaskStore revisedState:', revisedState);
+//         return revisedState;
+//
+//       default:
+//         return state;
+//     }
+//   }
+// }
+//
+// export default new TaskStore(Dispatcher);
+// import { ReduceStore } from 'flux/utils';
+// import Dispatcher from '../common/dispatcher/Dispatcher';
+//
+// class TaskStore extends ReduceStore {
+//   getInitialState () {
+//     return {
+//       allTaskGroupsCache: {}, // This is a dictionary key: taskGroupId, value: TaskGroup dict
+//       allTaskDefinitionsCache: {}, // This is a dictionary key: taskDefinitionId, value: TaskDefinition dict
+//       allTaskDependenciesCache: {}, // This is a dictionary key: taskDependencyId, value: TaskDependency dict
+//       allTasksCache: {}, // This is a dictionary key: personId, value: another dictionary key: taskDefinitionId, value: Task dict
+//       mostRecentTaskDefinitionIdSaved: -1,
+//       mostRecentTaskDefinitionSaved: {
+//         taskDefinitionId: -1,
+//       },
+//       mostRecentTaskGroupIdSaved: -1,
+//       mostRecentTaskGroupSaved: {
+//         firstName: '',
+//         lastName: '',
+//         taskDefinitionId: -1,
+//       },
+//       taskDefinitionsCompletedPersonIdList: {}, // This is a dictionary key: taskDefinitionId, value: list of personIds who have completed the TaskDefinition
+//       taskGroupCompletedByPersonList: {}, // This is a dictionary key: taskGroupId, value: list of personIds who have completed the TaskGroup
+//       searchResults: [],
+//     };
+//   }
+//
+//   getAllCachedTaskDefinitionsList () {
+//     const { allTaskDefinitionsCache } = this.getState();
+//     const taskDefinitionListRaw = Object.values(allTaskDefinitionsCache);
+//
+//     const taskDefinitionList = [];
+//     let taskDefinitionFiltered;
+//     let taskDefinitionRaw;
+//     for (let i = 0; i < taskDefinitionListRaw.length; i++) {
+//       taskDefinitionRaw = taskDefinitionListRaw[i];
+//       // console.log('TaskStore getAllCachedTaskDefinitionsList taskDefinition:', taskDefinition);
+//       taskDefinitionFiltered = taskDefinitionRaw;
+//       taskDefinitionList.push(taskDefinitionFiltered);
+//     }
+//     return taskDefinitionList;
+//   }
+//
+//   getAllCachedTaskGroupList () {
+//     const { allTaskGroupsCache } = this.getState();
+//     const taskGroupListRaw = Object.values(allTaskGroupsCache);
+//
+//     const taskGroupList = [];
+//     let taskGroupFiltered;
+//     let taskGroupRaw;
+//     for (let i = 0; i < taskGroupListRaw.length; i++) {
+//       taskGroupRaw = taskGroupListRaw[i];
+//       // console.log('TaskStore getAllCachedTaskDefinitionsList taskGroup:', taskGroup);
+//       taskGroupFiltered = taskGroupRaw;
+//       taskGroupList.push(taskGroupFiltered);
+//     }
+//     return taskGroupList;
+//   }
+//
+//   getMostRecentTaskGroupChanged () {
+//     // console.log('TaskStore getMostRecentTaskGroupChanged Id:', this.getState().mostRecentTaskGroupIdSaved);
+//     if (this.getState().mostRecentTaskGroupIdSaved !== -1) {
+//       return this.getTaskGroupById(this.getState().mostRecentTaskGroupIdSaved);
+//     }
+//     return {};
+//   }
+//
+//   getMostRecentTaskGroupIdChanged () {
+//     // console.log('TaskStore getMostRecentTaskGroupChanged Id:', this.getState().mostRecentTaskGroupIdSaved);
+//     return this.getState().mostRecentTaskGroupIdSaved;
+//   }
+//
+//   getTask (personId, taskDefinitionId) {
+//     const { allTasksCache } = this.getState();
+//     // console.log('TaskStore getTaskListDictByPersonId:', personId, ', allTasksCache:', allTasksCache);
+//     return allTasksCache[personId][taskDefinitionId] || {};
+//   }
+//
+//   getTaskDefinitionListByTaskGroupId (taskGroupId) {
+//     const { allTaskDefinitionsCache } = this.getState();
+//     const taskDefinitionListRaw = Object.values(allTaskDefinitionsCache);
+//     const taskDefinitionListForTaskDefinition = [];
+//     for (let i = 0; i < taskDefinitionListRaw.length; i++) {
+//       if (taskDefinitionListRaw[i].taskGroupId === taskGroupId) {
+//         taskDefinitionListForTaskDefinition.push(taskDefinitionListRaw[i]);
+//       }
+//     }
+//     // console.log('TaskStore getTaskDefinitionById:', taskDefinitionId, ', taskDefinitionListForTaskDefinition:', taskDefinitionListForTaskDefinition);
+//     return taskDefinitionListForTaskDefinition;
+//   }
+//
+//   getTaskGroupById (taskGroupId) {
+//     const { allTaskGroupsCache } = this.getState();
+//     // console.log('TaskStore getTaskGroupById:', taskGroupId, ', allTaskGroupsCache:', allTaskGroupsCache);
+//     return allTaskGroupsCache[taskGroupId] || {};
+//   }
+//
+//   getTaskGroupIdByTaskDefinitionId (taskDefinitionId) {
+//     const taskDefinitionDict = this.getTaskDefinitionById(taskDefinitionId);
+//     return taskDefinitionDict.taskGroupId || -1;
+//   }
+//
+//   getTaskDefinitionById (taskDefinitionId) {
+//     const { allTaskDefinitionsCache } = this.getState();
+//     // console.log('TaskStore getTaskDefinitionById:', taskDefinitionId, ', allTaskDefinitionsCache:', allTaskDefinitionsCache);
+//     return allTaskDefinitionsCache[taskDefinitionId] || {};
+//   }
+//
+//   getTaskListDictByPersonId (personId) {
+//     const { allTasksCache } = this.getState();
+//     // console.log('TaskStore getTaskListDictByPersonId:', personId, ', allTasksCache:', allTasksCache);
+//     return allTasksCache[personId] || {};
+//   }
+//
+//   getTaskListForPerson (personId) {
+//     const taskDict = this.getTaskListDictByPersonId(personId);
+//     const taskList = Object.values(taskDict);
+//     // console.log('TaskStore getTasksCompletedByPersonList:', personId, ', taskDefinitionsCompletedPersonIdList:', taskDefinitionsCompletedPersonIdList);
+//     return taskList || [];
+//   }
+//
+//   getSearchResults () {
+//     // console.log('TaskStore getSearchResults:', this.getState().searchResults);
+//     return this.getState().searchResults || [];
+//   }
+//
+//   reduce (state, action) {
+//     const {
+//       allTaskGroupsCache, allTaskDefinitionsCache, allTasksCache,
+//     } = state;
+//     let missingRequiredVariable = false;
+//     let personId = -1;
+//     let taskDefinitionId = -1;
+//     let revisedState = state;
+//     let searchResults = [];
+//     let taskGroupId = -1;
+//
+//     switch (action.type) {
+//       case 'task-definition-list-retrieve':
+//         if (!action.res.success) {
+//           console.log('TaskStore ', action.type, ' FAILED action.res:', action.res);
+//           return state;
+//         }
+//         revisedState = state;
+//         // console.log('TaskStore task-definition-list-retrieve taskDefinitionList:', action.res.taskDefinitionList);
+//         if (action.res.isSearching && action.res.isSearching === true) {
+//           // console.log('TaskStore isSearching:', action.res.isSearching);
+//           searchResults = action.res.taskDefinitionList;
+//           // console.log('TaskStore searchResults:', searchResults);
+//           revisedState = {
+//             ...revisedState,
+//             searchResults,
+//           };
+//         }
+//         if (action.res.taskDefinitionList) {
+//           action.res.taskDefinitionList.forEach((taskDefinition) => {
+//             // console.log('TaskStore task-definition-list-retrieve adding taskDefinition:', taskDefinition);
+//             if (taskDefinition && (taskDefinition.id >= 0)) {
+//               allTaskDefinitionsCache[taskDefinition.id] = taskDefinition;
+//             }
+//           });
+//           // console.log('allTaskDefinitionsCache:', allTaskDefinitionsCache);
+//           revisedState = {
+//             ...revisedState,
+//             allTaskDefinitionsCache,
+//           };
+//         }
+//         // console.log('TaskStore revisedState:', revisedState);
+//         return revisedState;
+//
+//       case 'task-definition-save':
+//         if (!action.res.success) {
+//           console.log('TaskStore ', action.type, ' FAILED action.res:', action.res);
+//           return state;
+//         }
+//         revisedState = state;
+//         if (action.res.taskDefinitionId >= 0) {
+//           taskDefinitionId = action.res.taskDefinitionId;
+//         } else {
+//           taskDefinitionId = -1;
+//         }
+//
+//         if (taskDefinitionId >= 0) {
+//           if (action.res.taskDefinitionCreated || action.res.taskDefinitionUpdated) {
+//             // console.log('TaskStore taskDefinition-save taskDefinitionId:', taskDefinitionId);
+//             allTaskDefinitionsCache[taskDefinitionId] = action.res;
+//             revisedState = {
+//               ...revisedState,
+//               allTaskDefinitionsCache,
+//               mostRecentTaskDefinitionIdSaved: taskDefinitionId,
+//             };
+//           } else {
+//             console.log('TaskStore task-definition-save NOT updated or saved.');
+//           }
+//         } else {
+//           console.log('TaskStore task-definition-save MISSING taskDefinitionId:', taskDefinitionId);
+//         }
+//         return revisedState;
+//
+//       case 'task-group-list-retrieve':
+//         if (!action.res.success) {
+//           console.log('TaskStore ', action.type, ' FAILED action.res:', action.res);
+//           return state;
+//         }
+//         revisedState = state;
+//         // console.log('TaskStore task-group-list-retrieve taskGroupList:', action.res.taskGroupList);
+//         if (action.res.isSearching && action.res.isSearching === true) {
+//           // console.log('TaskStore isSearching:', action.res.isSearching);
+//           searchResults = action.res.taskGroupList;
+//           // console.log('TaskStore searchResults:', searchResults);
+//           revisedState = {
+//             ...revisedState,
+//             searchResults,
+//           };
+//         }
+//         if (action.res.taskGroupList) {
+//           action.res.taskGroupList.forEach((taskGroup) => {
+//             // console.log('TaskStore task-group-list-retrieve adding taskGroup:', taskGroup);
+//             if (taskGroup && (taskGroup.id >= 0)) {
+//               allTaskGroupsCache[taskGroup.id] = taskGroup;
+//             }
+//           });
+//           // console.log('allTaskGroupsCache:', allTaskGroupsCache);
+//           revisedState = {
+//             ...revisedState,
+//             allTaskGroupsCache,
+//           };
+//         }
+//         // console.log('TaskStore revisedState:', revisedState);
+//         return revisedState;
+//
+//       case 'task-group-save':
+//         if (!action.res.success) {
+//           console.log('TaskStore ', action.type, ' FAILED action.res:', action.res);
+//           return state;
+//         }
+//         revisedState = state;
+//         if (action.res.taskGroupId >= 0) {
+//           taskGroupId = action.res.taskGroupId;
+//         } else {
+//           taskGroupId = -1;
+//         }
+//
+//         if (taskGroupId >= 0) {
+//           // console.log('TaskStore task-group-save taskGroupId:', taskGroupId);
+//           allTaskGroupsCache[taskGroupId] = action.res;
+//           revisedState = {
+//             ...revisedState,
+//             allTaskGroupsCache,
+//             mostRecentTaskGroupIdSaved: taskGroupId,
+//           };
+//         } else {
+//           console.log('TaskStore task-group-save MISSING taskGroupId:', taskGroupId);
+//         }
+//         return revisedState;
+//
+//       case 'task-save':
+//         if (!action.res.success) {
+//           console.log('TaskStore ', action.type, ' FAILED action.res:', action.res);
+//           return state;
+//         }
+//         missingRequiredVariable = false;
+//         revisedState = state;
+//         if (action.res.personId >= 0) {
+//           personId = action.res.personId;
+//         } else {
+//           personId = -1;
+//           missingRequiredVariable = true;
+//         }
+//         if (action.res.taskDefinitionId >= 0) {
+//           taskDefinitionId = action.res.taskDefinitionId;
+//         } else {
+//           taskDefinitionId = -1;
+//           missingRequiredVariable = true;
+//         }
+//
+//         if (!missingRequiredVariable) {
+//           // console.log('TaskStore task-save personId:', personId, ', taskDefinitionId:', taskDefinitionId);
+//           allTasksCache[personId][taskDefinitionId] = action.res;
+//           revisedState = {
+//             ...revisedState,
+//             allTasksCache,
+//           };
+//         } else {
+//           console.log('TaskStore task-save MISSING_REQUIRED_VARIABLE personId:', personId, ', taskDefinitionId:', taskDefinitionId);
+//         }
+//         return revisedState;
+//
+//       case 'task-status-list-retrieve':
+//         if (!action.res.success) {
+//           console.log('TaskStore ', action.type, ' FAILED action.res:', action.res);
+//           return state;
+//         }
+//         revisedState = state;
+//         // console.log('TaskStore task-definition-list-retrieve taskDefinitionList:', action.res.taskDefinitionList);
+//         if (action.res.taskDefinitionList) {
+//           action.res.taskDefinitionList.forEach((taskDefinition) => {
+//             // console.log('TaskStore task-definition-list-retrieve adding taskDefinition:', taskDefinition);
+//             if (taskDefinition && (taskDefinition.id >= 0)) {
+//               allTaskDefinitionsCache[taskDefinition.id] = taskDefinition;
+//             }
+//           });
+//           // console.log('allTaskDefinitionsCache:', allTaskDefinitionsCache);
+//           revisedState = {
+//             ...revisedState,
+//             allTaskDefinitionsCache,
+//           };
+//         }
+//         if (action.res.taskGroupList) {
+//           action.res.taskGroupList.forEach((taskGroup) => {
+//             // console.log('TaskStore task-group-list-retrieve adding taskGroup:', taskGroup);
+//             if (taskGroup && (taskGroup.id >= 0)) {
+//               allTaskGroupsCache[taskGroup.id] = taskGroup;
+//             }
+//           });
+//           // console.log('allTaskGroupsCache:', allTaskGroupsCache);
+//           revisedState = {
+//             ...revisedState,
+//             allTaskGroupsCache,
+//           };
+//         }
+//         if (action.res.taskList) {
+//           action.res.taskList.forEach((task) => {
+//             // console.log('TaskStore task-group-list-retrieve adding taskGroup:', taskGroup);
+//             if (task && (task.personId >= 0)) {
+//               if (!allTasksCache[task.personId]) {
+//                 allTasksCache[task.personId] = {};
+//               }
+//               if (task && (task.taskDefinitionId >= 0)) {
+//                 allTasksCache[task.personId][task.taskDefinitionId] = task;
+//               } else {
+//                 console.log('TaskStore task-group-list-retrieve skipping task with missing personId:', task);
+//               }
+//             } else {
+//               console.log('TaskStore task-group-list-retrieve skipping task with missing taskDefinitionId:', task);
+//             }
+//           });
+//           // console.log('allTasksCache:', allTasksCache);
+//           revisedState = {
+//             ...revisedState,
+//             allTasksCache,
+//           };
+//         }
+//         // console.log('TaskStore revisedState:', revisedState);
+//         return revisedState;
+//
+//       default:
+//         return state;
+//     }
+//   }
+// }
+//
+// export default new TaskStore(Dispatcher);

--- a/src/js/stores/TeamStore.js
+++ b/src/js/stores/TeamStore.js
@@ -1,282 +1,282 @@
-import { ReduceStore } from 'flux/utils';
-import Dispatcher from '../common/dispatcher/Dispatcher';
-import PersonStore from './PersonStore';
-import arrayContains from '../common/utils/arrayContains';
-import convertToInteger from '../common/utils/convertToInteger';
-
-class TeamStore extends ReduceStore {
-  getInitialState () {
-    return {
-      allTeamsCache: {}, // This is a dictionary key: teamId, value: team dict
-      allTeamMembersCache: {}, // This is a dictionary key: teamId, value: list of personIds in the team
-      mostRecentTeamIdSaved: -1,
-      mostRecentTeamMemberIdSaved: -1,
-      mostRecentTeamSaved: {
-        teamName: '',
-        teamId: '',
-      },
-    };
-  }
-
-  getMostRecentTeamChanged () {
-    // console.log('TeamStore getMostRecentTeamChanged Id:', this.getState().mostRecentTeamIdSaved);
-    if (this.getState().mostRecentTeamIdSaved !== -1) {
-      return this.getTeamById(this.getState().mostRecentTeamIdSaved);
-    }
-    return {};
-  }
-
-  getTeamById (teamId) {
-    const { allTeamsCache } = this.getState();
-    // console.log('TeamStore getTeamById:', teamId, ', allTeamsCache:', allTeamsCache);
-    return allTeamsCache[teamId] || {};
-  }
-
-  getTeamList () {
-    const { allTeamsCache } = this.getState();
-    const teamListRaw = Object.values(allTeamsCache);
-
-    const teamList = [];
-    let teamFiltered;
-    let teamRaw;
-    for (let i = 0; i < teamListRaw.length; i++) {
-      teamRaw = teamListRaw[i];
-      // console.log('TeamStore getTeamMemberList person:', person);
-      teamFiltered = teamRaw;
-      teamList.push(teamFiltered);
-    }
-    return teamList;
-  }
-
-  getTeamMemberList (teamId) {
-    const { allTeamMembersCache } = this.getState();
-    // console.log('TeamStore getTeamMemberList teamId:', teamId, ', allTeamMembersCache:', allTeamMembersCache);
-    const personIdList = allTeamMembersCache[teamId] || [];
-    const teamMemberList = [];
-    for (let i = 0; i < personIdList.length; i++) {
-      const person = PersonStore.getPersonById(personIdList[i]);
-      // console.log('TeamStore getTeamMemberList person:', person);
-      if (person) {
-        teamMemberList.push(person);
-      }
-    }
-    return teamMemberList;
-  }
-
-  getTeamMemberPersonIdList (teamId) {
-    const { allTeamMembersCache } = this.getState();
-    return allTeamMembersCache[teamId] || [];
-  }
-
-  getTeamName (teamId) {
-    const team = this.getTeamById(teamId);
-    return team.teamName || '';
-  }
-
-  reduce (state, action) {
-    const { allTeamMembersCache, allTeamsCache } = state;
-    let personId = -1;
-    let personIdTemp = -1;
-    let revisedState = state;
-    let teamId = -1;
-    let teamIdTemp = -1;
-    let teamList = [];
-    let teamMemberList = [];
-    let teamMemberIdList = [];
-
-    switch (action.type) {
-      case 'add-person-to-team':
-        if (!action.res.success) {
-          console.log('TeamStore ', action.type, ' FAILED action.res:', action.res);
-          return state;
-        }
-        revisedState = state;
-        // console.log('TeamStore add-person-to-team action.res: ', action.res);
-        personIdTemp = convertToInteger(action.res.personId);
-        if (personIdTemp >= 0) {
-          personId = personIdTemp;
-        } else {
-          personId = -1;
-        }
-        if (action.res.teamId >= 0) {
-          teamId = action.res.teamId;
-        } else {
-          teamId = -1;
-        }
-        if (personId >= 0 && teamId >= 0) {
-          // console.log('TeamStore add-person-to-team personId: ', personId, ', teamId:', teamId);
-          // Start with existing teamMemberList
-          teamMemberIdList = allTeamMembersCache[teamId] || [];
-          // Check if personId is already in teamMemberListAdd personId to teamMemberList
-          if (!arrayContains(personId, teamMemberIdList)) {
-            teamMemberIdList.push(personId);
-            allTeamMembersCache[teamId] = teamMemberIdList;
-            revisedState = {
-              ...revisedState,
-              allTeamMembersCache,
-              mostRecentTeamMemberIdSaved: personId,
-            };
-          }
-        } else {
-          console.log('TeamStore add-person-to-team MISSING personId: ', personId, ' OR teamId:', teamId);
-        }
-
-        return revisedState;
-
-      case 'remove-person-from-team':
-        if (!action.res.success) {
-          console.log('TeamStore ', action.type, ' FAILED action.res:', action.res);
-          return state;
-        }
-        revisedState = state;
-        // console.log('TeamStore add-person-to-team action.res: ', action.res);
-        personIdTemp = convertToInteger(action.res.personId);
-        if (personIdTemp >= 0) {
-          personId = personIdTemp;
-        } else {
-          personId = -1;
-        }
-        teamIdTemp = convertToInteger(action.res.teamId);
-        if (teamIdTemp >= 0) {
-          teamId = teamIdTemp;
-        } else {
-          teamId = -1;
-        }
-        if (personId >= 0 && teamId >= 0) {
-          // console.log('TeamStore remove-person-from-team personId: ', personId, ', teamId:', teamId);
-          // Start with existing teamMemberList
-          teamMemberIdList = allTeamMembersCache[teamId] || [];
-          // If personId is in teamMemberListAdd, remove it
-          if (arrayContains(personId, teamMemberIdList)) {
-            teamMemberIdList = teamMemberIdList.filter((item) => item !== personId);
-            allTeamMembersCache[teamId] = teamMemberIdList;
-            revisedState = {
-              ...revisedState,
-              allTeamMembersCache,
-              mostRecentTeamMemberIdSaved: personId,
-            };
-          }
-        } else {
-          console.log('TeamStore remove-person-from-team MISSING personId: ', personId, ' OR teamId:', teamId);
-        }
-        return revisedState;
-
-      case 'team-list-retrieve':
-        if (!action.res.success) {
-          console.log('TeamStore ', action.type, ' FAILED action.res:', action.res);
-          return state;
-        }
-        teamList = action.res.teamList || [];
-        revisedState = state;
-        teamList.forEach((team) => {
-          if (team && (team.id >= 0)) {
-            allTeamsCache[team.id] = team;
-            if (team.teamMemberList) {
-              teamMemberIdList = [];
-              teamMemberList = team.teamMemberList || [];
-              teamMemberList.forEach((person) => {
-                if (person && (person.id >= 0) && !arrayContains(person.id, teamMemberIdList)) {
-                  teamMemberIdList.push(person.id);
-                }
-              });
-              allTeamMembersCache[team.id] = teamMemberIdList;
-            }
-          }
-        });
-
-        revisedState = {
-          ...revisedState,
-          allTeamMembersCache,
-          allTeamsCache,
-        };
-        return revisedState;
-
-      case 'team-retrieve':
-        if (!action.res.success) {
-          console.log('TeamStore ', action.type, ' FAILED action.res:', action.res);
-          return state;
-        }
-        teamIdTemp = convertToInteger(action.res.teamId);
-        if (teamIdTemp >= 0) {
-          teamId = teamIdTemp;
-        } else {
-          teamId = -1;
-          console.log('TeamStore team-retrieve MISSING teamId: ', teamId);
-        }
-        // console.log('TeamStore team-retrieve teamId:', teamId);
-        teamMemberIdList = [];
-        revisedState = state;
-
-        // console.log('OrganizationStore issueDescriptionsRetrieve issueList:', issueList);
-        if (teamId >= 0) {
-          allTeamsCache[teamId] = action.res;
-          if (action.res.teamMemberList) {
-            // If missing teamMemberList do not alter data in the store
-            teamMemberList = action.res.teamMemberList || [];
-            teamMemberList.forEach((person) => {
-              if (person && (person.id >= 0) && !arrayContains(person.id, teamMemberIdList)) {
-                teamMemberIdList.push(person.id);
-              }
-            });
-            allTeamMembersCache[teamId] = teamMemberIdList;
-            revisedState = {
-              ...revisedState,
-              allTeamMembersCache,
-            };
-          }
-          // console.log('allTeamMembersCache:', allTeamMembersCache);
-          // console.log('allCachedOrganizationsDict:', allCachedOrganizationsDict);
-          revisedState = {
-            ...revisedState,
-            allTeamsCache,
-          };
-        }
-        return revisedState;
-
-      case 'team-save':
-        if (!action.res.success) {
-          console.log('TeamStore ', action.type, ' FAILED action.res:', action.res);
-          return state;
-        }
-        revisedState = state;
-        teamIdTemp = convertToInteger(action.res.teamId);
-        if (teamIdTemp >= 0) {
-          teamId = teamIdTemp;
-        } else {
-          teamId = -1;
-        }
-        if (teamId >= 0) {
-          // console.log('TeamStore team-save teamId:', teamId);
-          allTeamsCache[teamId] = action.res;
-          if (action.res.teamMemberList) {
-            // If missing teamMemberList do not alter data in the store
-            teamMemberList = action.res.teamMemberList || [];
-            teamMemberList.forEach((person) => {
-              if (person && (person.id >= 0) && !arrayContains(person.id, teamMemberIdList)) {
-                teamMemberIdList.push(person.id);
-              }
-            });
-            allTeamMembersCache[teamId] = teamMemberIdList;
-            revisedState = {
-              ...revisedState,
-              allTeamMembersCache,
-            };
-          }
-          revisedState = {
-            ...revisedState,
-            allTeamsCache,
-            mostRecentTeamIdSaved: teamId,
-          };
-        } else {
-          console.log('TeamStore person-save MISSING teamId:', teamId);
-        }
-
-        return revisedState;
-
-      default:
-        return state;
-    }
-  }
-}
-
-export default new TeamStore(Dispatcher);
+// import { ReduceStore } from 'flux/utils';
+// import Dispatcher from '../common/dispatcher/Dispatcher';
+// import PersonStore from './PersonStore';
+// import arrayContains from '../common/utils/arrayContains';
+// import convertToInteger from '../common/utils/convertToInteger';
+//
+// class TeamStore extends ReduceStore {
+//   getInitialState () {
+//     return {
+//       allTeamsCache: {}, // This is a dictionary key: teamId, value: team dict
+//       allTeamMembersCache: {}, // This is a dictionary key: teamId, value: list of personIds in the team
+//       mostRecentTeamIdSaved: -1,
+//       mostRecentTeamMemberIdSaved: -1,
+//       mostRecentTeamSaved: {
+//         teamName: '',
+//         teamId: '',
+//       },
+//     };
+//   }
+//
+//   getMostRecentTeamChanged () {
+//     // console.log('TeamStore getMostRecentTeamChanged Id:', this.getState().mostRecentTeamIdSaved);
+//     if (this.getState().mostRecentTeamIdSaved !== -1) {
+//       return this.getTeamById(this.getState().mostRecentTeamIdSaved);
+//     }
+//     return {};
+//   }
+//
+//   getTeamById (teamId) {
+//     const { allTeamsCache } = this.getState();
+//     // console.log('TeamStore getTeamById:', teamId, ', allTeamsCache:', allTeamsCache);
+//     return allTeamsCache[teamId] || {};
+//   }
+//
+//   getTeamList () {
+//     const { allTeamsCache } = this.getState();
+//     const teamListRaw = Object.values(allTeamsCache);
+//
+//     const teamList = [];
+//     let teamFiltered;
+//     let teamRaw;
+//     for (let i = 0; i < teamListRaw.length; i++) {
+//       teamRaw = teamListRaw[i];
+//       // console.log('TeamStore getTeamMemberList person:', person);
+//       teamFiltered = teamRaw;
+//       teamList.push(teamFiltered);
+//     }
+//     return teamList;
+//   }
+//
+//   getTeamMemberList (teamId) {
+//     const { allTeamMembersCache } = this.getState();
+//     // console.log('TeamStore getTeamMemberList teamId:', teamId, ', allTeamMembersCache:', allTeamMembersCache);
+//     const personIdList = allTeamMembersCache[teamId] || [];
+//     const teamMemberList = [];
+//     for (let i = 0; i < personIdList.length; i++) {
+//       const person = PersonStore.getPersonById(personIdList[i]);
+//       // console.log('TeamStore getTeamMemberList person:', person);
+//       if (person) {
+//         teamMemberList.push(person);
+//       }
+//     }
+//     return teamMemberList;
+//   }
+//
+//   getTeamMemberPersonIdList (teamId) {
+//     const { allTeamMembersCache } = this.getState();
+//     return allTeamMembersCache[teamId] || [];
+//   }
+//
+//   getTeamName (teamId) {
+//     const team = this.getTeamById(teamId);
+//     return team.teamName || '';
+//   }
+//
+//   reduce (state, action) {
+//     const { allTeamMembersCache, allTeamsCache } = state;
+//     let personId = -1;
+//     let personIdTemp = -1;
+//     let revisedState = state;
+//     let teamId = -1;
+//     let teamIdTemp = -1;
+//     let teamList = [];
+//     let teamMemberList = [];
+//     let teamMemberIdList = [];
+//
+//     switch (action.type) {
+//       case 'add-person-to-team':
+//         if (!action.res.success) {
+//           console.log('TeamStore ', action.type, ' FAILED action.res:', action.res);
+//           return state;
+//         }
+//         revisedState = state;
+//         // console.log('TeamStore add-person-to-team action.res: ', action.res);
+//         personIdTemp = convertToInteger(action.res.personId);
+//         if (personIdTemp >= 0) {
+//           personId = personIdTemp;
+//         } else {
+//           personId = -1;
+//         }
+//         if (action.res.teamId >= 0) {
+//           teamId = action.res.teamId;
+//         } else {
+//           teamId = -1;
+//         }
+//         if (personId >= 0 && teamId >= 0) {
+//           // console.log('TeamStore add-person-to-team personId: ', personId, ', teamId:', teamId);
+//           // Start with existing teamMemberList
+//           teamMemberIdList = allTeamMembersCache[teamId] || [];
+//           // Check if personId is already in teamMemberListAdd personId to teamMemberList
+//           if (!arrayContains(personId, teamMemberIdList)) {
+//             teamMemberIdList.push(personId);
+//             allTeamMembersCache[teamId] = teamMemberIdList;
+//             revisedState = {
+//               ...revisedState,
+//               allTeamMembersCache,
+//               mostRecentTeamMemberIdSaved: personId,
+//             };
+//           }
+//         } else {
+//           console.log('TeamStore add-person-to-team MISSING personId: ', personId, ' OR teamId:', teamId);
+//         }
+//
+//         return revisedState;
+//
+//       case 'remove-person-from-team':
+//         if (!action.res.success) {
+//           console.log('TeamStore ', action.type, ' FAILED action.res:', action.res);
+//           return state;
+//         }
+//         revisedState = state;
+//         // console.log('TeamStore add-person-to-team action.res: ', action.res);
+//         personIdTemp = convertToInteger(action.res.personId);
+//         if (personIdTemp >= 0) {
+//           personId = personIdTemp;
+//         } else {
+//           personId = -1;
+//         }
+//         teamIdTemp = convertToInteger(action.res.teamId);
+//         if (teamIdTemp >= 0) {
+//           teamId = teamIdTemp;
+//         } else {
+//           teamId = -1;
+//         }
+//         if (personId >= 0 && teamId >= 0) {
+//           // console.log('TeamStore remove-person-from-team personId: ', personId, ', teamId:', teamId);
+//           // Start with existing teamMemberList
+//           teamMemberIdList = allTeamMembersCache[teamId] || [];
+//           // If personId is in teamMemberListAdd, remove it
+//           if (arrayContains(personId, teamMemberIdList)) {
+//             teamMemberIdList = teamMemberIdList.filter((item) => item !== personId);
+//             allTeamMembersCache[teamId] = teamMemberIdList;
+//             revisedState = {
+//               ...revisedState,
+//               allTeamMembersCache,
+//               mostRecentTeamMemberIdSaved: personId,
+//             };
+//           }
+//         } else {
+//           console.log('TeamStore remove-person-from-team MISSING personId: ', personId, ' OR teamId:', teamId);
+//         }
+//         return revisedState;
+//
+//       case 'team-list-retrieve':
+//         if (!action.res.success) {
+//           console.log('TeamStore ', action.type, ' FAILED action.res:', action.res);
+//           return state;
+//         }
+//         teamList = action.res.teamList || [];
+//         revisedState = state;
+//         teamList.forEach((team) => {
+//           if (team && (team.id >= 0)) {
+//             allTeamsCache[team.id] = team;
+//             if (team.teamMemberList) {
+//               teamMemberIdList = [];
+//               teamMemberList = team.teamMemberList || [];
+//               teamMemberList.forEach((person) => {
+//                 if (person && (person.id >= 0) && !arrayContains(person.id, teamMemberIdList)) {
+//                   teamMemberIdList.push(person.id);
+//                 }
+//               });
+//               allTeamMembersCache[team.id] = teamMemberIdList;
+//             }
+//           }
+//         });
+//
+//         revisedState = {
+//           ...revisedState,
+//           allTeamMembersCache,
+//           allTeamsCache,
+//         };
+//         return revisedState;
+//
+//       case 'team-retrieve':
+//         if (!action.res.success) {
+//           console.log('TeamStore ', action.type, ' FAILED action.res:', action.res);
+//           return state;
+//         }
+//         teamIdTemp = convertToInteger(action.res.teamId);
+//         if (teamIdTemp >= 0) {
+//           teamId = teamIdTemp;
+//         } else {
+//           teamId = -1;
+//           console.log('TeamStore team-retrieve MISSING teamId: ', teamId);
+//         }
+//         // console.log('TeamStore team-retrieve teamId:', teamId);
+//         teamMemberIdList = [];
+//         revisedState = state;
+//
+//         // console.log('OrganizationStore issueDescriptionsRetrieve issueList:', issueList);
+//         if (teamId >= 0) {
+//           allTeamsCache[teamId] = action.res;
+//           if (action.res.teamMemberList) {
+//             // If missing teamMemberList do not alter data in the store
+//             teamMemberList = action.res.teamMemberList || [];
+//             teamMemberList.forEach((person) => {
+//               if (person && (person.id >= 0) && !arrayContains(person.id, teamMemberIdList)) {
+//                 teamMemberIdList.push(person.id);
+//               }
+//             });
+//             allTeamMembersCache[teamId] = teamMemberIdList;
+//             revisedState = {
+//               ...revisedState,
+//               allTeamMembersCache,
+//             };
+//           }
+//           // console.log('allTeamMembersCache:', allTeamMembersCache);
+//           // console.log('allCachedOrganizationsDict:', allCachedOrganizationsDict);
+//           revisedState = {
+//             ...revisedState,
+//             allTeamsCache,
+//           };
+//         }
+//         return revisedState;
+//
+//       case 'team-save':
+//         if (!action.res.success) {
+//           console.log('TeamStore ', action.type, ' FAILED action.res:', action.res);
+//           return state;
+//         }
+//         revisedState = state;
+//         teamIdTemp = convertToInteger(action.res.teamId);
+//         if (teamIdTemp >= 0) {
+//           teamId = teamIdTemp;
+//         } else {
+//           teamId = -1;
+//         }
+//         if (teamId >= 0) {
+//           // console.log('TeamStore team-save teamId:', teamId);
+//           allTeamsCache[teamId] = action.res;
+//           if (action.res.teamMemberList) {
+//             // If missing teamMemberList do not alter data in the store
+//             teamMemberList = action.res.teamMemberList || [];
+//             teamMemberList.forEach((person) => {
+//               if (person && (person.id >= 0) && !arrayContains(person.id, teamMemberIdList)) {
+//                 teamMemberIdList.push(person.id);
+//               }
+//             });
+//             allTeamMembersCache[teamId] = teamMemberIdList;
+//             revisedState = {
+//               ...revisedState,
+//               allTeamMembersCache,
+//             };
+//           }
+//           revisedState = {
+//             ...revisedState,
+//             allTeamsCache,
+//             mostRecentTeamIdSaved: teamId,
+//           };
+//         } else {
+//           console.log('TeamStore person-save MISSING teamId:', teamId);
+//         }
+//
+//         return revisedState;
+//
+//       default:
+//         return state;
+//     }
+//   }
+// }
+//
+// export default new TeamStore(Dispatcher);

--- a/src/js/utils/cordovaUtilsPageEnumeration.js
+++ b/src/js/utils/cordovaUtilsPageEnumeration.js
@@ -1,7 +1,6 @@
-import CordovaPageConstants from '../constants/CordovaPageConstants';
-import AppObservableStore from '../stores/AppObservableStore';
 import { normalizedHref } from '../common/utils/hrefUtils';
 import stringContains from '../common/utils/stringContains';
+import CordovaPageConstants from '../constants/CordovaPageConstants';
 
 // eslint-disable-next-line import/prefer-default-export
 export function pageEnumeration () {
@@ -93,8 +92,8 @@ export function pageEnumeration () {
   } else if (path.includes('/') && (
     path.includes('btcand') || path.includes('btmeas') || path.includes('/btdb'))) {
     return CordovaPageConstants.twitterInfoPage;
-  } else if (AppObservableStore.getShowTwitterLandingPage()) {
-    return CordovaPageConstants.twitterHandleLanding;
+  // } else if (AppObservableStore.getShowTwitterLandingPage()) {
+  //   return CordovaPageConstants.twitterHandleLanding;
   }
   return CordovaPageConstants.defaultVal;
 }


### PR DESCRIPTION
In some cases I fell back to code from last week, leaving newer code that was not fully working in place, but commented out.

At this point every ReactQuery call works perfectly (without overriding the config values set in App.jsx) and I tested them many many times. 

In TeamMemberList, I revived last week's working code, and left in place the code that uses apiCache.  In TeamMemberList I now do a diff to show the differences from data straight out of ReactQuery (which has matched SQL every time that I have checked it manually), with the processed data that is stored in apiCache -- there currently is a discrepancy in apiDataCache.  That diff should be useful in the future, and could be generalized.

I did not test or fix the Questionnaire drawer yet.

This is an incremental checkin, and I'll now work on getting the apiDataCache working as it exists.  (Although it would be my strong preference to get it working by using ReactQuery's internal cache as the single cache for unaltered API results, and to generate the processed output through what is now apiDataCache, from data that is immediately pulled from ReactQuery's internal cache.)
