### PR TITLE
Making it easier to get a link to any questionnaire for any person. Stopped processing TaskGroups and TaskDefinitions from `task-status-list-retrieve` and started using the more limited APIs 'task-definition-list-retrieve' and 'task-group-list-retrieve'. Updated the Add Team Member quick-person-add list to work with new data flow.

### DIFF
--- a/src/js/components/Person/PersonProfile.jsx
+++ b/src/js/components/Person/PersonProfile.jsx
@@ -1,39 +1,88 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { renderLog } from '../../common/utils/logging';
-import { useConnectAppContext } from '../../contexts/ConnectAppContext';
-// import useGetFullNamePreferredReactQuery from '../../react-query/useGetFullNamePreferredReactQuery';
+import { useConnectAppContext, useConnectDispatch } from '../../contexts/ConnectAppContext';
 import CopyQuestionnaireLink from '../Questionnaire/CopyQuestionnaireLink';
-import { useGetFullNamePreferred, useGetPersonById } from '../../models/PersonModel';
+import { useGetFullNamePreferred } from '../../models/PersonModel';
+import { SpanWithLinkStyle } from '../Style/linkStyles';
+import { METHOD, useFetchData } from '../../react-query/WeConnectQuery';
+import { captureQuestionnaireListRetrieveData } from '../../models/QuestionnaireModel';
 
 
 const PersonProfile = () => {
   renderLog('PersonProfile');  // Set LOG_RENDER_EVENTS to log all renders
-  const { getAppContextValue, setAppContextValue } = useConnectAppContext();
+  const { getAppContextValue } = useConnectAppContext();
+  const { apiDataCache } = useConnectAppContext();
+  const { allQuestionnairesCache } = apiDataCache;
+  const dispatch = useConnectDispatch();
 
-  // const [person] = useState(getAppContextValue('personDrawersPerson'));
-  const [person] = useState(useGetPersonById(getAppContextValue('personDrawersPersonId')));
+  const [personId] = useState(getAppContextValue('personDrawersPersonId'));
+  const [questionnaireList, setQuestionnaireList] = useState([]);
+  const [showQuestionnaireList, setShowQuestionnaireList] = useState(false);
+
+  const questionnaireListRetrieveResults = useFetchData(['questionnaire-list-retrieve'], {}, METHOD.GET);
+  useEffect(() => {
+    // console.log('questionnaireListRetrieveResults in Questionnaire useEffect captureQuestionnaireListRetrieveData');
+    if (questionnaireListRetrieveResults) {
+      captureQuestionnaireListRetrieveData(questionnaireListRetrieveResults, apiDataCache, dispatch);
+    }
+  }, [questionnaireListRetrieveResults, allQuestionnairesCache]);
 
   useEffect(() => {
-    // Hard coded temporarily while we are in development
-    setAppContextValue('QuestionnaireId', 1);
-  }, []);
+    if (allQuestionnairesCache) {
+      setQuestionnaireList(Object.values(allQuestionnairesCache));
+    }
+  }, [allQuestionnairesCache]);
 
   return (
     <PersonProfileWrapper>
       <FullName>
-        {useGetFullNamePreferred(person.personId)}
+        {useGetFullNamePreferred(personId)}
       </FullName>
       {/* <PersonDetails /> This was commented out as of January 28th, 2025 */}
-      <CopyQuestionnaireLink />
+      <ShowQuestionnaireOptions>
+        <div>
+          Questionnaires
+          {' '}
+          (
+          {showQuestionnaireList ? (
+            <SpanWithLinkStyle onClick={() => setShowQuestionnaireList(false)}>hide</SpanWithLinkStyle>
+          ) : (
+            <SpanWithLinkStyle onClick={() => setShowQuestionnaireList(true)}>show</SpanWithLinkStyle>
+          )}
+          )
+        </div>
+      </ShowQuestionnaireOptions>
+      {showQuestionnaireList && (
+        <QuestionnaireOptions>
+          {questionnaireList.map((questionnaire) => (
+            <OneQuestionnaire key={`questionnaire-${questionnaire.questionnaireId}`}>
+              <div>{questionnaire.questionnaireName}</div>
+              <CopyQuestionnaireLink personId={personId} questionnaireId={questionnaire.questionnaireId} />
+            </OneQuestionnaire>
+          ))}
+        </QuestionnaireOptions>
+      )}
     </PersonProfileWrapper>
   );
 };
 
-const FullName = styled('div')`
+const FullName = styled('h2')`
+`;
+
+const OneQuestionnaire = styled('div')`
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 10px;
 `;
 
 const PersonProfileWrapper = styled('div')`
+`;
+
+const QuestionnaireOptions = styled('div')`
+`;
+
+const ShowQuestionnaireOptions = styled('div')`
 `;
 
 export default PersonProfile;

--- a/src/js/components/Questionnaire/CopyQuestionnaireLink.jsx
+++ b/src/js/components/Questionnaire/CopyQuestionnaireLink.jsx
@@ -1,23 +1,17 @@
 import { withStyles } from '@mui/styles';
+import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import styled from 'styled-components';
 import { renderLog } from '../../common/utils/logging';
 import webAppConfig from '../../config';
-import { useConnectAppContext } from '../../contexts/ConnectAppContext';
 import { SpanWithLinkStyle } from '../Style/linkStyles';
-import { useGetPersonById } from '../../models/PersonModel';
 
 
-const CopyQuestionnaireLink = () => {
+const CopyQuestionnaireLink = ({ personId, questionnaireId }) => {
   renderLog('CopyQuestionnaireLink');
-  const { getAppContextValue } = useConnectAppContext();
-
-  // const [person] = useState(getAppContextValue('personDrawersPerson'));
-  const [person] = useState(useGetPersonById(getAppContextValue('personDrawersPersonId')));
-  const [questionnaireId] = useState(getAppContextValue('QuestionnaireId'));
   const [linkCopied, setLinkCopied] = useState(false);
-  const [linkToBeShared] = useState(`${webAppConfig.PROTOCOL}${webAppConfig.HOSTNAME}/q/${questionnaireId}/${person.id}`);
+  const [linkToBeShared] = useState(`${webAppConfig.PROTOCOL}${webAppConfig.HOSTNAME}/q/${questionnaireId}/${personId}`);
 
   const copyLink = () => {
     // console.log('CopyQuestionnaireLink copyLink');
@@ -31,20 +25,21 @@ const CopyQuestionnaireLink = () => {
     <CopyQuestionnaireLinkWrapper>
       <CopyToClipboard text={linkToBeShared} onCopy={copyLink}>
         <div>
-          {/* <div style={{ paddingBottom: '20px' }}> */}
-          {/*  Hi {person.firstName}! */}
-          {/* </div> */}
           {linkCopied ? (
             <div>Link copied!</div>
           ) : (
             <SpanWithLinkStyle>
-              copy questionnaire link
+              copy
             </SpanWithLinkStyle>
           )}
         </div>
       </CopyToClipboard>
     </CopyQuestionnaireLinkWrapper>
   );
+};
+CopyQuestionnaireLink.propTypes = {
+  personId: PropTypes.number.isRequired,
+  questionnaireId: PropTypes.number.isRequired,
 };
 
 const styles = () => ({

--- a/src/js/components/Questionnaire/EditQuestionForm.jsx
+++ b/src/js/components/Questionnaire/EditQuestionForm.jsx
@@ -104,7 +104,7 @@ const EditQuestionForm = ({ classes }) => {
     };
     const requestParams = makeRequestParams(plainParams, params);
     mutate(requestParams);
-    console.log('saveQuestionnaire requestParams:', requestParams);
+    // console.log('saveQuestionnaire requestParams:', requestParams);
     setSaveButtonActive(false);
     setAppContextValue('editQuestionDrawerOpen', false);
     setAppContextValue('selectedQuestion', undefined);

--- a/src/js/components/Questionnaire/EditQuestionnaireForm.jsx
+++ b/src/js/components/Questionnaire/EditQuestionnaireForm.jsx
@@ -73,7 +73,7 @@ const EditQuestionnaireForm = ({ classes }) => {
           margin="dense"
           name="questionnaireName"
           onChange={() => updateSaveButton()}
-          placeholder="Name of the questionnaire, staff only"
+          placeholder="Name of the questionnaire, hr staff only"
           variant="outlined"
         />
         <TextField

--- a/src/js/components/Task/EditTaskDefinitionForm.jsx
+++ b/src/js/components/Task/EditTaskDefinitionForm.jsx
@@ -70,10 +70,7 @@ const EditTaskDefinitionForm = ({ classes }) => {
   };
 
   const updateSaveButton = () => {
-    if (taskNameFldRef.current.value && taskNameFldRef.current.value.length &&
-      taskDescFldRef.current.value && taskDescFldRef.current.value.length &&
-      taskInstFldRef.current.value && taskInstFldRef.current.value.length &&
-      taskUrlFldRef.current.value && taskUrlFldRef.current.value.length) {
+    if (taskNameFldRef.current.value && taskNameFldRef.current.value.length) {
       if (!saveButtonActive) {
         setSaveButtonActive(true);
       }

--- a/src/js/components/Team/TeamMemberList.jsx
+++ b/src/js/components/Team/TeamMemberList.jsx
@@ -33,11 +33,9 @@ const TeamMemberList = ({ teamId, team }) => { // teamMemberList
   }, [dataTLR, isSuccessTLR]);
 
   useEffect(() => {
-    // console.log(`TeamMemberList useEffect teamId: ${teamId} apiDataCache:`, apiDataCache);
     const updatedTeamMemberList = getTeamMembersListByTeamId(teamId, apiDataCache);
-    // console.log(`TeamMemberList useEffect teamId: ${teamId} updatedTeamMemberList:`, updatedTeamMemberList);
     setTeamMemberListApiDataCache(updatedTeamMemberList);
-  }, [allPeopleCache, allTeamsCache, teamId]);
+  }, [apiDataCache, teamId]);
 
   // const oneTeam = teamList.find((tm) => tm.teamId === parseInt(teamId));
 

--- a/src/js/contexts/ConnectAppContext.jsx
+++ b/src/js/contexts/ConnectAppContext.jsx
@@ -89,8 +89,8 @@ export const ConnectAppContextProvider = ({ children }) => {
   //   // console.log('useFetchData in TeamHome (person-list-retrieve) useEffect:', dataP, isSuccessP, isFetchingP, isStaleP);
   //   if (isSuccessP) {
   //     // console.log('useFetchData in TeamHome (person-list-retrieve)useEffect data good:', dataP, isSuccessP, isFetchingP, isStaleP);
-  //     setAppContextValue('allStaffList', dataP ? dataP.personList : []);
-  //     // console.log('ConnectAppContext useEffect allStaffList fetched');
+  //     setAppContextValue('allPeopleList', dataP ? dataP.personList : []);
+  //     // console.log('ConnectAppContext useEffect allPeopleList fetched');
   //   }
   // }, [dataP, isSuccessP, isFetchingP]);
 

--- a/src/js/models/TaskModel.jsx
+++ b/src/js/models/TaskModel.jsx
@@ -26,32 +26,19 @@ export function getInitialGlobalTaskVariables () {
 }
 
 // This is called after making this fetchData request:
-// const taskStatusListRetrieveResults = useFetchData(['task-status-list-retrieve'], { personIdList: personIdsList });
-// eslint-disable-next-line import/prefer-default-export
-export function captureTaskStatusListRetrieveData (
+// const taskStatusListRetrieveResults = useFetchData(['task-definition-list-retrieve'], {});
+export function captureTaskDefinitionListRetrieveData (
   incomingRetrieveResults = {},
   apiDataCache = {},
   dispatch,
 ) {
   const { data, isSuccess } = incomingRetrieveResults;
   const allTaskDefinitionsCache = apiDataCache.allTaskDefinitionsCache || {};
-  const allTaskDependenciesCache = apiDataCache.allTaskDependenciesCache || {};
-  const allTaskGroupsCache = apiDataCache.allTaskGroupsCache || {};
-  const allTasksCache = apiDataCache.allTasksCache || {};
   const changeResults = {
     allTaskDefinitionsCache,
     allTaskDefinitionsCacheChanged: false,
-    allTaskDependenciesCache,
-    allTaskDependenciesCacheChanged: false,
-    allTaskGroupsCache,
-    allTaskGroupsCacheChanged: false,
-    allTasksCache,
-    allTasksCacheChanged: false,
   };
   const allTaskDefinitionsCacheNew = { ...allTaskDefinitionsCache };
-  // const allTaskDependenciesCacheNew = { ...allTaskDependenciesCache };
-  const allTaskGroupsCacheNew = { ...allTaskGroupsCache };
-  const allTasksCacheNew = { ...allTasksCache };
   let newTaskDefinitionListDataReceived = false;
   if (data && data.taskDefinitionList && isSuccess === true) {
     data.taskDefinitionList.forEach((taskDefinition) => {
@@ -66,8 +53,29 @@ export function captureTaskStatusListRetrieveData (
       }
     });
   }
-  // let newTaskDependenciesListDataReceived = false;
-  // TODO TaskDependencies API processing when data available
+  if (newTaskDefinitionListDataReceived) {
+    // console.log('TaskStatusListRetrieve setting allTaskDefinitionsCacheNew:', allTaskDefinitionsCacheNew);
+    dispatch({ type: 'updateByKeyValue', key: 'allTaskDefinitionsCache', value: allTaskDefinitionsCacheNew });
+    changeResults.allTaskDefinitionsCache = allTaskDefinitionsCacheNew;
+    changeResults.allTaskDefinitionsCacheChanged = true;
+  }
+  return changeResults;
+}
+
+// This is called after making this fetchData request:
+// const taskStatusListRetrieveResults = useFetchData(['task-group-list-retrieve'], {});
+export function captureTaskGroupListRetrieveData (
+  incomingRetrieveResults = {},
+  apiDataCache = {},
+  dispatch,
+) {
+  const { data, isSuccess } = incomingRetrieveResults;
+  const allTaskGroupsCache = apiDataCache.allTaskGroupsCache || {};
+  const changeResults = {
+    allTaskGroupsCache,
+    allTaskGroupsCacheChanged: false,
+  };
+  const allTaskGroupsCacheNew = { ...allTaskGroupsCache };
   let newTaskGroupListDataReceived = false;
   if (data && data.taskGroupList && isSuccess === true) {
     data.taskGroupList.forEach((taskGroup) => {
@@ -82,6 +90,72 @@ export function captureTaskStatusListRetrieveData (
       }
     });
   }
+  if (newTaskGroupListDataReceived) {
+    // console.log('TaskStatusListRetrieve setting allTaskGroupsCacheNew:', allTaskGroupsCacheNew);
+    dispatch({ type: 'updateByKeyValue', key: 'allTaskGroupsCache', value: allTaskGroupsCacheNew });
+    changeResults.allTaskGroupsCache = allTaskGroupsCacheNew;
+    changeResults.allTaskGroupsCacheChanged = true;
+  }
+  return changeResults;
+}
+
+// This is called after making this fetchData request:
+// const taskStatusListRetrieveResults = useFetchData(['task-status-list-retrieve'], { personIdList: personIdsList });
+// TODO: Dale still thinking about this. Please leave this commented out code until April 2025
+export function captureTaskStatusListRetrieveData (
+  incomingRetrieveResults = {},
+  apiDataCache = {},
+  dispatch,
+) {
+  const { data, isSuccess } = incomingRetrieveResults;
+  // const allTaskDefinitionsCache = apiDataCache.allTaskDefinitionsCache || {};
+  // const allTaskDependenciesCache = apiDataCache.allTaskDependenciesCache || {};
+  // const allTaskGroupsCache = apiDataCache.allTaskGroupsCache || {};
+  const allTasksCache = apiDataCache.allTasksCache || {};
+  const changeResults = {
+    // allTaskDefinitionsCache,
+    // allTaskDefinitionsCacheChanged: false,
+    // allTaskDependenciesCache,
+    // allTaskDependenciesCacheChanged: false,
+    // allTaskGroupsCache,
+    // allTaskGroupsCacheChanged: false,
+    allTasksCache,
+    allTasksCacheChanged: false,
+  };
+  // const allTaskDefinitionsCacheNew = { ...allTaskDefinitionsCache };
+  // const allTaskDependenciesCacheNew = { ...allTaskDependenciesCache };
+  // const allTaskGroupsCacheNew = { ...allTaskGroupsCache };
+  const allTasksCacheNew = { ...allTasksCache };
+  // let newTaskDefinitionListDataReceived = false;
+  // if (data && data.taskDefinitionList && isSuccess === true) {
+  //   data.taskDefinitionList.forEach((taskDefinition) => {
+  //     if (taskDefinition && taskDefinition.taskDefinitionId && taskDefinition.taskDefinitionId >= 0) {
+  //       if (!allTaskDefinitionsCacheNew[taskDefinition.taskDefinitionId]) {
+  //         allTaskDefinitionsCacheNew[taskDefinition.taskDefinitionId] = taskDefinition;
+  //         newTaskDefinitionListDataReceived = true;
+  //       } else if (!isEqual(taskDefinition, allTaskDefinitionsCacheNew[taskDefinition.taskDefinitionId])) {
+  //         allTaskDefinitionsCacheNew[taskDefinition.taskDefinitionId] = taskDefinition;
+  //         newTaskDefinitionListDataReceived = true;
+  //       }
+  //     }
+  //   });
+  // }
+  // let newTaskDependenciesListDataReceived = false;
+  // TODO TaskDependencies API processing when data available
+  // let newTaskGroupListDataReceived = false;
+  // if (data && data.taskGroupList && isSuccess === true) {
+  //   data.taskGroupList.forEach((taskGroup) => {
+  //     if (taskGroup && taskGroup.taskGroupId && taskGroup.taskGroupId >= 0) {
+  //       if (!allTaskGroupsCacheNew[taskGroup.taskGroupId]) {
+  //         allTaskGroupsCacheNew[taskGroup.taskGroupId] = taskGroup;
+  //         newTaskGroupListDataReceived = true;
+  //       } else if (!isEqual(taskGroup, allTaskGroupsCacheNew[taskGroup.taskGroupId])) {
+  //         allTaskGroupsCacheNew[taskGroup.taskGroupId] = taskGroup;
+  //         newTaskGroupListDataReceived = true;
+  //       }
+  //     }
+  //   });
+  // }
   let newTaskListDataReceived = false;
   if (data && data.taskList && isSuccess === true) {
     data.taskList.forEach((task) => {
@@ -98,31 +172,31 @@ export function captureTaskStatusListRetrieveData (
         }
       }
     });
-    if (newTaskDefinitionListDataReceived) {
-      // console.log('TaskStatusListRetrieve setting allTaskDefinitionsCacheNew:', allTaskDefinitionsCacheNew);
-      dispatch({ type: 'updateByKeyValue', key: 'allTaskDefinitionsCache', value: allTaskDefinitionsCacheNew });
-      changeResults.allTaskDefinitionsCache = allTaskDefinitionsCacheNew;
-      changeResults.allTaskDefinitionsCacheChanged = true;
-    }
-    // if (newTaskDependenciesListDataReceived) {
-    //   // console.log('TaskStatusListRetrieve setting allTaskDependenciesCacheNew:', allTaskDependenciesCacheNew);
-    //   dispatch({ type: 'updateByKeyValue', key: 'allTaskDependenciesCache', value: allTaskDependenciesCacheNew });
-    //   changeResults.allTaskDependenciesCache = allTaskDependenciesCacheNew;
-    //   changeResults.allTaskDependenciesCacheChanged = true;
-    // }
-    if (newTaskListDataReceived) {
-      // console.log('TaskStatusListRetrieve setting allTasksCacheNew:', allTasksCacheNew);
-      dispatch({ type: 'updateByKeyValue', key: 'allTasksCache', value: allTasksCacheNew });
-      changeResults.allTasksCache = allTasksCacheNew;
-      changeResults.allTasksCacheChanged = true;
-    }
-    if (newTaskGroupListDataReceived) {
-      // console.log('TaskStatusListRetrieve setting allTaskGroupsCacheNew:', allTaskGroupsCacheNew);
-      dispatch({ type: 'updateByKeyValue', key: 'allTaskGroupsCache', value: allTaskGroupsCacheNew });
-      changeResults.allTaskGroupsCache = allTaskGroupsCacheNew;
-      changeResults.allTaskGroupsCacheChanged = true;
-    }
   }
+  // if (newTaskDefinitionListDataReceived) {
+  //   // console.log('TaskStatusListRetrieve setting allTaskDefinitionsCacheNew:', allTaskDefinitionsCacheNew);
+  //   dispatch({ type: 'updateByKeyValue', key: 'allTaskDefinitionsCache', value: allTaskDefinitionsCacheNew });
+  //   changeResults.allTaskDefinitionsCache = allTaskDefinitionsCacheNew;
+  //   changeResults.allTaskDefinitionsCacheChanged = true;
+  // }
+  // if (newTaskDependenciesListDataReceived) {
+  //   // console.log('TaskStatusListRetrieve setting allTaskDependenciesCacheNew:', allTaskDependenciesCacheNew);
+  //   dispatch({ type: 'updateByKeyValue', key: 'allTaskDependenciesCache', value: allTaskDependenciesCacheNew });
+  //   changeResults.allTaskDependenciesCache = allTaskDependenciesCacheNew;
+  //   changeResults.allTaskDependenciesCacheChanged = true;
+  // }
+  if (newTaskListDataReceived) {
+    // console.log('TaskStatusListRetrieve setting allTasksCacheNew:', allTasksCacheNew);
+    dispatch({ type: 'updateByKeyValue', key: 'allTasksCache', value: allTasksCacheNew });
+    changeResults.allTasksCache = allTasksCacheNew;
+    changeResults.allTasksCacheChanged = true;
+  }
+  // if (newTaskGroupListDataReceived) {
+  //   // console.log('TaskStatusListRetrieve setting allTaskGroupsCacheNew:', allTaskGroupsCacheNew);
+  //   dispatch({ type: 'updateByKeyValue', key: 'allTaskGroupsCache', value: allTaskGroupsCacheNew });
+  //   changeResults.allTaskGroupsCache = allTaskGroupsCacheNew;
+  //   changeResults.allTaskGroupsCacheChanged = true;
+  // }
   return changeResults;
 }
 

--- a/src/js/pages/SystemSettings/Questionnaire.jsx
+++ b/src/js/pages/SystemSettings/Questionnaire.jsx
@@ -3,7 +3,7 @@ import { withStyles } from '@mui/styles';
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
-import { Link, useLocation } from 'react-router';
+import { Link, useParams } from 'react-router';
 import styled from 'styled-components';
 import DesignTokenColors from '../../common/components/Style/DesignTokenColors';
 import { renderLog } from '../../common/utils/logging';
@@ -22,19 +22,18 @@ const Questionnaire = ({ classes }) => {
   const { apiDataCache } = useConnectAppContext();
   const { allQuestionsCache, allQuestionnairesCache } = apiDataCache;
   const dispatch = useConnectDispatch();
-  const { pathname } = useLocation();
-  const pathSegments = pathname.split('/').filter(Boolean);
-  const targetQuestionnaireId = parseInt(pathSegments[1], 10); // Assuming the questionnaireId is the second segment of the path
-  const getQuestionsForQuestionnaire = (questionnaireId) => {
+
+  const [questionList, setQuestionList] = useState([]);
+  const [questionnaire, setQuestionnaire] = useState(getAppContextValue('selectedQuestionnaire'));
+
+  const targetQuestionnaireId = parseInt(useParams().questionnaireId, 10);
+  const getQuestionsForQuestionnaire = (incomingQuestionnaireId) => {
     if (allQuestionsCache) {
-      return Object.values(allQuestionsCache).filter((question) => question.questionnaireId === questionnaireId);
+      return Object.values(allQuestionsCache).filter((question) => question.questionnaireId === incomingQuestionnaireId);
     }
     return [];
   };
   const questionsForCurrentQuestionnaire = getQuestionsForQuestionnaire(targetQuestionnaireId) || [];
-
-  const [questionList, setQuestionList] = useState([]);
-  const [questionnaire, setQuestionnaire] = useState(getAppContextValue('selectedQuestionnaire'));
 
   const questionnaireListRetrieveResults = useFetchData(['questionnaire-list-retrieve'], {}, METHOD.GET);
   useEffect(() => {
@@ -55,9 +54,8 @@ const Questionnaire = ({ classes }) => {
   useEffect(() => {
     // console.log('Questionnaire useEffect setQuestionnaire targetQuestionnaireId:', targetQuestionnaireId);
     if (allQuestionnairesCache) {
-      const questionnaireIdTemp = pathSegments[1];
-      if (questionnaireIdTemp && allQuestionnairesCache[questionnaireIdTemp]) {
-        setQuestionnaire(allQuestionnairesCache[questionnaireIdTemp]);
+      if (targetQuestionnaireId && allQuestionnairesCache[targetQuestionnaireId]) {
+        setQuestionnaire(allQuestionnairesCache[targetQuestionnaireId]);
       }
     }
   }, [allQuestionnairesCache]);
@@ -132,7 +130,7 @@ const Questionnaire = ({ classes }) => {
           <QuestionListWrapper>
             {questionList.map((question) => (
               <OneQuestionnaireWrapper key={`questionnaire-${question.id}`}>
-                Question: {question.questionText}
+                {question.questionText}
                 {' '}
                 {question.requireAnswer && (
                   <RequiredStar> *</RequiredStar>

--- a/src/js/pages/SystemSettings/SystemSettings.jsx
+++ b/src/js/pages/SystemSettings/SystemSettings.jsx
@@ -15,7 +15,9 @@ import { useConnectAppContext, useConnectDispatch } from '../../contexts/Connect
 import { METHOD, useFetchData } from '../../react-query/WeConnectQuery';
 import { captureQuestionnaireListRetrieveData } from '../../models/QuestionnaireModel';
 import capturePersonListRetrieveData from '../../models/capturePersonListRetrieveData';
-import { captureTaskStatusListRetrieveData } from '../../models/TaskModel';
+import {
+  captureTaskDefinitionListRetrieveData, captureTaskGroupListRetrieveData, captureTaskStatusListRetrieveData,
+} from '../../models/TaskModel';
 
 
 const SystemSettings = ({ classes }) => {
@@ -45,6 +47,20 @@ const SystemSettings = ({ classes }) => {
       captureQuestionnaireListRetrieveData(questionnaireListRetrieveResults, apiDataCache, dispatch);
     }
   }, [questionnaireListRetrieveResults, allQuestionnairesCache, apiDataCache, dispatch]);
+
+  const taskDefinitionListRetrieveResults = useFetchData(['task-definition-list-retrieve'], {}, METHOD.GET);
+  useEffect(() => {
+    if (taskDefinitionListRetrieveResults) {
+      captureTaskDefinitionListRetrieveData(taskDefinitionListRetrieveResults, apiDataCache, dispatch);
+    }
+  }, [apiDataCache, dispatch, taskDefinitionListRetrieveResults]);
+
+  const taskGroupListRetrieveResults = useFetchData(['task-group-list-retrieve'], {}, METHOD.GET);
+  useEffect(() => {
+    if (taskGroupListRetrieveResults) {
+      captureTaskGroupListRetrieveData(taskGroupListRetrieveResults, apiDataCache, dispatch);
+    }
+  }, [apiDataCache, dispatch, taskGroupListRetrieveResults]);
 
   const taskStatusListRetrieveResults = useFetchData(['task-status-list-retrieve'], { personIdList: personIdsList }, METHOD.GET);
   useEffect(() => {

--- a/src/js/pages/SystemSettings/TaskGroup.jsx
+++ b/src/js/pages/SystemSettings/TaskGroup.jsx
@@ -14,7 +14,9 @@ import webAppConfig from '../../config';
 import { useConnectAppContext, useConnectDispatch } from '../../contexts/ConnectAppContext';
 import { METHOD, useFetchData } from '../../react-query/WeConnectQuery';
 import capturePersonListRetrieveData from '../../models/capturePersonListRetrieveData';
-import { captureTaskStatusListRetrieveData } from '../../models/TaskModel';
+import {
+  captureTaskDefinitionListRetrieveData, captureTaskGroupListRetrieveData, captureTaskStatusListRetrieveData,
+} from '../../models/TaskModel';
 
 
 const TaskGroup = ({ classes }) => {
@@ -38,6 +40,20 @@ const TaskGroup = ({ classes }) => {
       capturePersonListRetrieveData(personListRetrieveResults, apiDataCache, dispatch);
     }
   }, [personListRetrieveResults, allPeopleCache, dispatch]);
+
+  const taskDefinitionListRetrieveResults = useFetchData(['task-definition-list-retrieve'], {}, METHOD.GET);
+  useEffect(() => {
+    if (taskDefinitionListRetrieveResults) {
+      captureTaskDefinitionListRetrieveData(taskDefinitionListRetrieveResults, apiDataCache, dispatch);
+    }
+  }, [apiDataCache, dispatch, taskDefinitionListRetrieveResults]);
+
+  const taskGroupListRetrieveResults = useFetchData(['task-group-list-retrieve'], {}, METHOD.GET);
+  useEffect(() => {
+    if (taskGroupListRetrieveResults) {
+      captureTaskGroupListRetrieveData(taskGroupListRetrieveResults, apiDataCache, dispatch);
+    }
+  }, [apiDataCache, dispatch, taskGroupListRetrieveResults]);
 
   const taskStatusListRetrieveResults = useFetchData(['task-status-list-retrieve'], { personIdList: personIdsList }, METHOD.GET);
   useEffect(() => {

--- a/src/js/pages/Tasks.jsx
+++ b/src/js/pages/Tasks.jsx
@@ -12,7 +12,9 @@ import TaskListForPerson from '../components/Task/TaskListForPerson';
 import webAppConfig from '../config';
 import { useConnectAppContext, useConnectDispatch } from '../contexts/ConnectAppContext';
 import capturePersonListRetrieveData from '../models/capturePersonListRetrieveData';
-import { captureTaskStatusListRetrieveData } from '../models/TaskModel';
+import {
+  captureTaskDefinitionListRetrieveData, captureTaskGroupListRetrieveData, captureTaskStatusListRetrieveData,
+} from '../models/TaskModel';
 import { captureTeamListRetrieveData } from '../models/TeamModel';
 import { METHOD, useFetchData } from '../react-query/WeConnectQuery';
 
@@ -36,6 +38,20 @@ const Tasks = ({ classes, match }) => {
       capturePersonListRetrieveData(personListRetrieveResults, apiDataCache, dispatch);
     }
   }, [personListRetrieveResults, allPeopleCache, dispatch]);
+
+  const taskDefinitionListRetrieveResults = useFetchData(['task-definition-list-retrieve'], {}, METHOD.GET);
+  useEffect(() => {
+    if (taskDefinitionListRetrieveResults) {
+      captureTaskDefinitionListRetrieveData(taskDefinitionListRetrieveResults, apiDataCache, dispatch);
+    }
+  }, [apiDataCache, dispatch, taskDefinitionListRetrieveResults]);
+
+  const taskGroupListRetrieveResults = useFetchData(['task-group-list-retrieve'], {}, METHOD.GET);
+  useEffect(() => {
+    if (taskGroupListRetrieveResults) {
+      captureTaskGroupListRetrieveData(taskGroupListRetrieveResults, apiDataCache, dispatch);
+    }
+  }, [apiDataCache, dispatch, taskGroupListRetrieveResults]);
 
   const taskStatusListRetrieveResults = useFetchData(['task-status-list-retrieve'], { personIdList: personIdsList }, METHOD.GET);
   useEffect(() => {

--- a/src/js/pages/TeamHome.jsx
+++ b/src/js/pages/TeamHome.jsx
@@ -28,7 +28,7 @@ const TeamHome = ({ classes }) => {
   const [teamId] = useState(convertToInteger(params.teamId));
 
   // const updateTeam = (tList) => {
-  //   const oneTeam = tList.find((staff) => staff.teamId === parseInt(teamId));
+  //   const oneTeam = tList.find((person) => person.teamId === parseInt(teamId));
   //   setTeam(oneTeam);
   // };
 
@@ -51,20 +51,19 @@ const TeamHome = ({ classes }) => {
       captureTeamListRetrieveData(teamListRetrieveResults, apiDataCache, dispatch);
       // console.log('Teams useEffect changeResults:', changeResults);
     }
-  }, [teamListRetrieveResults, allPeopleCache, allTeamsCache, dispatch]);
+  }, [teamListRetrieveResults, allTeamsCache, dispatch]);
 
   useEffect(() => {
     // console.log('TeamHome teamId: ', teamId, ', allTeamsCache:', allTeamsCache);
     if (allTeamsCache && teamId && allTeamsCache[teamId]) {
       setTeam(allTeamsCache[teamId]);
     }
-  }, [apiDataCache, teamId]);
+  }, [allTeamsCache, teamId]);
 
   const addTeamMemberClick = () => {
     // console.log('TeamHome addTeamMemberClick, teamId:', teamId);
     setAppContextValue('addPersonDrawerOpen', true);
     setAppContextValue('addPersonDrawerTeam', team);
-    setAppContextValue('teamId', team.id);
     const teamWithEmbeddedMemberList = (teamMemberLists && teamMemberLists.teamList.filter((list) => list.id === team.id)[0]) || [];
     setAppContextValue('addPersonDrawerTeamMemberList', teamWithEmbeddedMemberList && teamWithEmbeddedMemberList.teamMemberList);
   };

--- a/src/js/react-query/useGetFullNamePreferredReactQuery.js
+++ b/src/js/react-query/useGetFullNamePreferredReactQuery.js
@@ -4,9 +4,9 @@ import { useConnectAppContext } from '../contexts/ConnectAppContext';
 // When the function name starts with 'use' React treats it as a custom hook, and it can then access Context variables
 const useGetFullNamePreferredReactQuery = (person) => {
   const { getAppContextValue } = useConnectAppContext();
-  const [allStaffList] = useState(getAppContextValue('allStaffList'));
+  const [allPeopleList] = useState(getAppContextValue('allPeopleList'));
   const [personId] = Object.values(person);  // This is silly, but this is a proof of concept
-  const foundPerson = allStaffList && allStaffList.find((onePerson) => onePerson.id === parseInt(personId));
+  const foundPerson = allPeopleList && allPeopleList.find((onePerson) => onePerson.id === parseInt(personId));
   let fullName = '';
   if (foundPerson?.id >= 0) {
     if (foundPerson?.firstNamePreferred) {


### PR DESCRIPTION
Making it easier to get a link to any questionnaire for any person. Stopped processing TaskGroups and TaskDefinitions from `task-status-list-retrieve` and started using the more limited APIs 'task-definition-list-retrieve' and 'task-group-list-retrieve'. Updated the Add Team Member quick-person-add list to work with new data flow.