### PR TITLE
First pass on viewerCanSeeOrDo & viewerAccessRights implementation. Added finer-grained viewerCanSeeOrDo switch to PersonSummaryRow & TeamHeader, so we turn off interface elements the person cannot access. Tested signin/signout, and confirmed that is still working. Registration requires manual browser refresh for signed in access rights to be recognized. Replaced loggedInPersonIsAdmin with viewerCanSeeOrDo & viewerAccessRights implementation. Control which PersonProfile we want to show with incoming prop. Working on bringing QuestionnaireResponsesList back to life. Implemented models/PersonModel - capturePersonRetrieveData. We may decide not to use person-retrieve in the future but I'd like to leave in place.

### DIFF
--- a/src/js/components/Navigation/HeaderBar.jsx
+++ b/src/js/components/Navigation/HeaderBar.jsx
@@ -38,6 +38,7 @@ const HeaderBar = ({ hideTabs }) => {
   }, [isAuth]);
 
   const logoutApi = async () => {
+    // I don't think we want to make the weConnectQueryFn call here since we are about to call mutateLogout
     const data = await weConnectQueryFn('logout', {}, METHOD.POST);
     console.log(`/logout response in HeaderBar -- status: '${'status'}',  data: ${JSON.stringify(data)}`);
     clearSignedInGlobals(setAppContextValue);

--- a/src/js/components/Person/PersonProfile.jsx
+++ b/src/js/components/Person/PersonProfile.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { renderLog } from '../../common/utils/logging';
@@ -9,14 +10,12 @@ import { METHOD, useFetchData } from '../../react-query/WeConnectQuery';
 import { captureQuestionnaireListRetrieveData } from '../../models/QuestionnaireModel';
 
 
-const PersonProfile = () => {
+const PersonProfile = ({ personId }) => {
   renderLog('PersonProfile');  // Set LOG_RENDER_EVENTS to log all renders
-  const { getAppContextValue } = useConnectAppContext();
   const { apiDataCache } = useConnectAppContext();
   const { allQuestionnairesCache } = apiDataCache;
   const dispatch = useConnectDispatch();
 
-  const [personId] = useState(getAppContextValue('personDrawersPersonId'));
   const [questionnaireList, setQuestionnaireList] = useState([]);
   const [showQuestionnaireList, setShowQuestionnaireList] = useState(false);
 
@@ -65,6 +64,9 @@ const PersonProfile = () => {
       )}
     </PersonProfileWrapper>
   );
+};
+PersonProfile.propTypes = {
+  personId: PropTypes.number,
 };
 
 const FullName = styled('h2')`

--- a/src/js/components/Person/PersonProfileDrawerMainContent.jsx
+++ b/src/js/components/Person/PersonProfileDrawerMainContent.jsx
@@ -1,17 +1,20 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { renderLog } from '../../common/utils/logging';
-// import QuestionnaireResponsesList from '../Questionnaire/QuestionnaireResponsesList';
+import { useConnectAppContext } from '../../contexts/ConnectAppContext';
+import QuestionnaireResponsesList from '../Questionnaire/QuestionnaireResponsesList';
 import PersonProfile from './PersonProfile';
 
 
 const PersonProfileDrawerMainContent = () => {
   renderLog('PersonProfileDrawerMainContent');
+  const { getAppContextValue } = useConnectAppContext();
+  const [personId] = useState(getAppContextValue('personDrawersPersonId'));
 
   return (
     <PersonProfileDrawerMainContentWrapper>
-      <PersonProfile />
-      {/* <QuestionnaireResponsesList /> */}
+      <PersonProfile personId={personId} />
+      <QuestionnaireResponsesList personId={personId} />
     </PersonProfileDrawerMainContentWrapper>
   );
 };

--- a/src/js/components/Person/PersonSummaryRow.jsx
+++ b/src/js/components/Person/PersonSummaryRow.jsx
@@ -11,16 +11,17 @@ import {
 } from '../../models/PersonModel';
 import { useRemoveTeamMemberMutation } from '../../react-query/mutations';
 import { DeleteStyled, EditStyled } from '../Style/iconStyles';
+import { viewerCanSeeOrDo } from '../../models/AuthModel';
 // import { useRemoveTeamMemberMutationDiverged } from '../../models/TeamModel';
 
 
 const PersonSummaryRow = ({ person, rowNumberForDisplay, teamId }) => {
   renderLog('PersonSummaryRow');  // Set LOG_RENDER_EVENTS to log all renders
-  // console.log('PersonSummaryRow location: ', person && person.location);
+  const { apiDataCache, setAppContextValue } = useConnectAppContext();
+  const { viewerAccessRights } = apiDataCache;
+  const { mutate } = useRemoveTeamMemberMutation();
 
   // const [person, setPerson] = useState(useGetPersonById(personId));  2/5/2025 does not work
-  const { setAppContextValue } = useConnectAppContext();
-  const { mutate } = useRemoveTeamMemberMutation();
 
   const removeTeamMemberClick = () => {
     const params = { personId: person.personId, teamId };
@@ -90,7 +91,7 @@ const PersonSummaryRow = ({ person, rowNumberForDisplay, teamId }) => {
       >
         {person.jobTitle}
       </PersonCell>
-      {hasEditRights ? (
+      {viewerCanSeeOrDo('canEditPersonAnyone', viewerAccessRights) ? (
         <PersonCell
           id={`editPerson-personId-${person.personId}`}
           onClick={() => editPersonClick(hasEditRights)}
@@ -102,7 +103,6 @@ const PersonSummaryRow = ({ person, rowNumberForDisplay, teamId }) => {
         </PersonCell>
       ) : (
         <PersonCell
-          id={`editPerson-personId-${person.personId}`}
           // cellwidth="20"
           cellwidth={20}
         >
@@ -111,7 +111,7 @@ const PersonSummaryRow = ({ person, rowNumberForDisplay, teamId }) => {
       )}
       {teamId > 0 && (
         <>
-          {hasEditRights ? (
+          {viewerCanSeeOrDo('canRemoveTeamMemberAnyTeam', viewerAccessRights) ? (
             <PersonCell
               id={`removeMember-personId-${person.personId}`}
               onClick={() => removeTeamMemberClick(person)}
@@ -123,8 +123,6 @@ const PersonSummaryRow = ({ person, rowNumberForDisplay, teamId }) => {
             </PersonCell>
           ) : (
             <PersonCell
-              id={`removeMember-personId-${person.personId}`}
-              onClick={() => removeTeamMemberClick(person)}
               // cellwidth="20"
               cellwidth={20}
             >

--- a/src/js/components/PrivateRoute.jsx
+++ b/src/js/components/PrivateRoute.jsx
@@ -1,12 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import { Navigate, Outlet, useLocation } from 'react-router';
 import { authLog } from '../common/utils/logging';
-import { useConnectAppContext } from '../contexts/ConnectAppContext';
+import { useConnectAppContext, useConnectDispatch } from '../contexts/ConnectAppContext';
 import { METHOD, useFetchData } from '../react-query/WeConnectQuery';
+import { captureAccessRightsData } from '../models/AuthModel';
 
 const PrivateRoute = () => {
   const location = useLocation();
-  const { getAppContextValue, setAppContextValue } = useConnectAppContext();
+  const { apiDataCache, getAppContextValue } = useConnectAppContext();
+  const dispatch = useConnectDispatch();
 
   const [isAuthenticated, setIsAuthenticated] = useState(null);
 
@@ -15,7 +17,8 @@ const PrivateRoute = () => {
     if (isSuccessAuth) {
       console.log('useFetchData in PrivateRoute useEffect dataAuth good:', dataAuth, isSuccessAuth);
       setIsAuthenticated(dataAuth.isAuthenticated);
-      setAppContextValue('loggedInPersonIsAdmin', dataAuth.loggedInPersonIsAdmin);
+      // setAppContextValue('loggedInPersonIsAdmin', dataAuth.loggedInPersonIsAdmin);
+      captureAccessRightsData(dataAuth, isSuccessAuth, apiDataCache, dispatch);
       authLog('========= PrivateRoute =========== INNER isAuthenticated: ', dataAuth.isAuthenticated);
     }
   }, [dataAuth, isSuccessAuth]);

--- a/src/js/components/Questionnaire/CopyQuestionnaireLink.jsx
+++ b/src/js/components/Questionnaire/CopyQuestionnaireLink.jsx
@@ -46,7 +46,7 @@ const styles = () => ({
 });
 
 
-const CopyQuestionnaireLinkWrapper = styled('div')`
+const CopyQuestionnaireLinkWrapper = styled('span')`
 `;
 
 export default withStyles(styles)(CopyQuestionnaireLink);

--- a/src/js/components/Questionnaire/QuestionnaireResponsesList.jsx
+++ b/src/js/components/Questionnaire/QuestionnaireResponsesList.jsx
@@ -41,7 +41,7 @@ const QuestionnaireResponsesList = ({ personId }) => {
       {questionnaireList.length > 0 && (
         <>
           <QuestionnaireResponses>
-            Questionnaire Responses
+            Answered
           </QuestionnaireResponses>
           <QuestionnaireListWrapper>
             {questionnaireList.map((questionnaire) => (
@@ -49,7 +49,7 @@ const QuestionnaireResponsesList = ({ personId }) => {
                 <QuestionText>
                   {questionnaire.questionnaireName}
                 </QuestionText>
-                <CopyQuestionnaireLink personId={personId} questionnaireId={questionnaire.id} />
+                {/* <CopyQuestionnaireLink personId={personId} questionnaireId={questionnaire.id} /> */}
                 <Suspense fallback={<></>}>
                   <OpenExternalWebSite
                     linkIdAttribute="view answers"
@@ -108,8 +108,7 @@ const QuestionText = styled('div')`
 `;
 
 const QuestionnaireListWrapper = styled('div')`
-  margin-top: 30px;
-  margin-left: 10px;
+  margin-bottom: 30px;
 `;
 
 export default QuestionnaireResponsesList;

--- a/src/js/components/Team/TeamHeader.jsx
+++ b/src/js/components/Team/TeamHeader.jsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router';
 import styled from 'styled-components';
 import { renderLog } from '../../common/utils/logging';
 import { useConnectAppContext } from '../../contexts/ConnectAppContext';
+import { viewerCanSeeOrDo } from '../../models/AuthModel';
 import { useRemoveTeamMutation } from '../../react-query/mutations';
 import { DeleteStyled, EditStyled } from '../Style/iconStyles';
 
@@ -12,7 +13,8 @@ import { DeleteStyled, EditStyled } from '../Style/iconStyles';
 // eslint-disable-next-line no-unused-vars
 const TeamHeader = ({ classes, showHeaderLabels, showIcons, team }) => {
   renderLog('TeamHeader');
-  const { getAppContextValue, setAppContextValue } = useConnectAppContext();
+  const { apiDataCache, getAppContextValue, setAppContextValue } = useConnectAppContext();
+  const { viewerAccessRights } = apiDataCache;
   const { mutate } = useRemoveTeamMutation();
 
   let teamLocal = team;
@@ -51,15 +53,23 @@ const TeamHeader = ({ classes, showHeaderLabels, showIcons, team }) => {
       </TeamHeaderCell>
       {/* Edit icon */}
       {showIcons && (
-        <TeamHeaderCell cellwidth={20} onClick={editTeamClick}>
-          <EditStyled />
-        </TeamHeaderCell>
+        <>
+          {viewerCanSeeOrDo('canEditTeamAnyTeam', viewerAccessRights) && (
+            <TeamHeaderCell cellwidth={20} onClick={editTeamClick}>
+              <EditStyled />
+            </TeamHeaderCell>
+          )}
+        </>
       )}
       {/* Delete icon */}
       {showIcons && (
-        <TeamHeaderCell cellwidth={20} onClick={removeTeamClick}>
-          <DeleteStyled />
-        </TeamHeaderCell>
+        <>
+          {viewerCanSeeOrDo('canRemoveTeam', viewerAccessRights) && (
+            <TeamHeaderCell cellwidth={20} onClick={removeTeamClick}>
+              <DeleteStyled />
+            </TeamHeaderCell>
+          )}
+        </>
       )}
     </OneTeamHeader>
   );

--- a/src/js/contexts/ConnectAppContext.jsx
+++ b/src/js/contexts/ConnectAppContext.jsx
@@ -3,6 +3,7 @@ import React, { createContext, useContext, useEffect, useReducer, useState } fro
 import initialApiDataCache from '../models/initialApiDataCache';
 // import capturePersonListRetrieveData from '../models/capturePersonListRetrieveData';
 import { METHOD, useFetchData } from '../react-query/WeConnectQuery';
+import { captureAccessRightsData } from '../models/AuthModel';
 // import { getInitialGlobalPersonVariables, PersonListRetrieveDataCapture } from '../models/PersonModel';
 // import { getInitialGlobalTaskVariables } from '../models/TaskModel';
 // import { getInitialGlobalTeamVariables } from '../models/TeamModel';
@@ -66,39 +67,6 @@ export const ConnectAppContextProvider = ({ children }) => {
     }
   };
 
-  // const { data: dataP, isSuccess: isSuccessP, isFetching: isFetchingP, isStale: isStaleP } = useFetchData(['person-list-retrieve'], {}, METHOD.GET);
-  // const personListRetrieveResults = useFetchData(['person-list-retrieve'], {}, METHOD.GET);
-  // This is not currently the right place to pass these values, but I'm saving these here for the next 30 days until we work out the correct place.
-  // {
-  //   cacheTime: 0,
-  //   networkMode: 'no-cache', <-- This is not a solution, it just covers up some problem in our code, while disabling the biggest benefit of ReactQueries.
-  //   refetchOnMount: true,
-  //   refetchOnWindowFocus: true,
-  //   refetchInterval: 0,
-  //   staleTime: 0,
-  // }
-
-  // Moved to root pages: Teams, TeamHome, etc.
-  // useEffect(() => {
-  //   // console.log('useFetchData person-list-retrieve in Teams useEffect:', personListRetrieveResults);
-  //   if (personListRetrieveResults) {
-  //     // console.log('In useEffect apiDataCache:', apiDataCache);
-  //     // const changeResults =
-  //     capturePersonListRetrieveData(personListRetrieveResults, apiDataCache, dispatch);
-  //     // console.log('ConnectAppContext useEffect capturePersonListRetrieveData changeResults:', changeResults);
-  //   }
-  // }, [personListRetrieveResults]);
-
-  // const { data: dataP, isSuccess: isSuccessP, isFetching: isFetchingP } = personListRetrieveResults;
-  // useEffect(() => {
-  //   // console.log('useFetchData in TeamHome (person-list-retrieve) useEffect:', dataP, isSuccessP, isFetchingP, isStaleP);
-  //   if (isSuccessP) {
-  //     // console.log('useFetchData in TeamHome (person-list-retrieve)useEffect data good:', dataP, isSuccessP, isFetchingP, isStaleP);
-  //     setAppContextValue('allPeopleList', dataP ? dataP.personList : []);
-  //     // console.log('ConnectAppContext useEffect allPeopleList fetched');
-  //   }
-  // }, [dataP, isSuccessP, isFetchingP]);
-
   // The following prints console log errors
   const { data: dataAuth, isSuccess: isSuccessAuth, isFetching: isFetchingAuth } = useFetchData(['get-auth'], {}, METHOD.POST);
   useEffect(() => {
@@ -108,7 +76,8 @@ export const ConnectAppContextProvider = ({ children }) => {
       setAppContextValue('authenticatedPerson', dataAuth.person);
       setAppContextValue('authenticatedPersonId', dataAuth.personId);
       setAppContextValue('isAuthenticated', isAuthenticated);
-      setAppContextValue('loggedInPersonIsAdmin', dataAuth.loggedInPersonIsAdmin);
+      // setAppContextValue('loggedInPersonIsAdmin', dataAuth.loggedInPersonIsAdmin);
+      captureAccessRightsData(dataAuth, isSuccessAuth, apiDataCache, dispatch);
 
       console.log('=============== ConnectAppContextProvider ======= isAuthenticated: ', isAuthenticated, ' ===========');
     }

--- a/src/js/contexts/contextFunctions.jsx
+++ b/src/js/contexts/contextFunctions.jsx
@@ -3,6 +3,6 @@ export const clearSignedInGlobals = (setAppContextValue) => {
   setAppContextValue('authenticatedPerson', undefined);
   setAppContextValue('authenticatedPersonId', -1);
   setAppContextValue('isAuthenticated', false);
-  setAppContextValue('loggedInPersonIsAdmin', false);
+  // setAppContextValue('loggedInPersonIsAdmin', false);
   setAppContextValue('personIsSignedIn', false);
 };

--- a/src/js/models/AuthModel.jsx
+++ b/src/js/models/AuthModel.jsx
@@ -1,0 +1,42 @@
+// AuthModel.js
+// Functions related to getting data from the apiDataCache, which stores data
+// received from our API servers.
+import isEqual from 'lodash-es/isEqual';
+
+
+export const viewerCanSeeOrDo = (accessRightName, viewerAccessRights) => {
+  if (!viewerAccessRights || !(accessRightName in viewerAccessRights)) {
+    return false;
+  }
+  return viewerAccessRights[accessRightName] || false;
+};
+
+export function captureAccessRightsData (data = {}, isSuccess = false, apiDataCache = {}, dispatch) {
+  const viewerAccessRights = apiDataCache.viewerAccessRights || {};
+  let changeResults = {
+    viewerAccessRights,
+    viewerAccessRightsChanged: false,
+  };
+  let viewerAccessRightsNew = { ...viewerAccessRights };
+  // console.log('captureAccessRightsData data:', data);
+  if (data && data.accessRights && isSuccess === true) {
+    let newDataReceived = false;
+    const { accessRights } = data;
+    if (accessRights && !('canAddPerson' in accessRights)) {
+      viewerAccessRightsNew = accessRights;
+      newDataReceived = true;
+    } else if (!isEqual(accessRights, viewerAccessRightsNew)) {
+      viewerAccessRightsNew = accessRights;
+      newDataReceived = true;
+    }
+    if (newDataReceived) {
+      // console.log('=== captureAccessRightsData viewerAccessRightsNew:', viewerAccessRightsNew, ', newDataReceived:', newDataReceived);
+      dispatch({ type: 'updateByKeyValue', key: 'viewerAccessRights', value: viewerAccessRightsNew });
+      changeResults = {
+        viewerAccessRights: viewerAccessRightsNew,
+        viewerAccessRightsChanged: true,
+      };
+    }
+  }
+  return changeResults;
+}

--- a/src/js/models/initialApiDataCache.js
+++ b/src/js/models/initialApiDataCache.js
@@ -3,6 +3,7 @@ const initialApiDataCache = () => {
   // These are the "AppContextValues" (i.e., global state variables) used in the PersonModel
   // console.log('initialApiDataCache called');  // This is worth logging, to see if we are reinitializing the apiDataCache unintentionally
   const initialGlobalPersonVariables = {
+    viewerAccessRights: {}, // This is a dictionary with what this person visiting the site can do
     allPeopleCache: {}, // This is a dictionary key: personId, value: person dict
     mostRecentPersonIdSaved: -1,
     mostRecentPersonSaved: {
@@ -11,6 +12,7 @@ const initialApiDataCache = () => {
       personId: '',
     },
     searchResults: [],
+    teamViewerAccessRights: {}, // This is a dictionary key: personId, value/2nd key: teamId, value: dict with what this person can do on that team
   };
 
   // These are the "AppContextValues" (i.e., global state variables) used in the PersonModel

--- a/src/js/pages/Login.jsx
+++ b/src/js/pages/Login.jsx
@@ -12,8 +12,9 @@ import compileDate from '../compileDate';
 import { PageContentContainer } from '../components/Style/pageLayoutStyles';
 import VerifySecretCodeModal from '../components/VerifySecretCodeModal';
 import webAppConfig from '../config';
-import { useConnectAppContext } from '../contexts/ConnectAppContext';
-import { clearSignedInGlobals } from '../contexts/contextFunctions';
+import { useConnectAppContext, useConnectDispatch } from '../contexts/ConnectAppContext';
+// import { clearSignedInGlobals } from '../contexts/contextFunctions';
+import { captureAccessRightsData } from '../models/AuthModel';
 import { getFullNamePreferredPerson } from '../models/PersonModel';
 import { useLogoutMutation } from '../react-query/mutations';
 import weConnectQueryFn, { METHOD, useFetchData } from '../react-query/WeConnectQuery';
@@ -24,7 +25,8 @@ const Login = ({ classes }) => {
   renderLog('Login');
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const { setAppContextValue } = useConnectAppContext();
+  const { apiDataCache, setAppContextValue } = useConnectAppContext();
+  const dispatch = useConnectDispatch();
   const { mutate: mutateLogout } = useLogoutMutation();
 
   const firstNameFldRef = useRef('');
@@ -54,7 +56,8 @@ const Login = ({ classes }) => {
       setAuthPerson(authenticatedPerson);
       const success = isAuthenticated && authenticatedPerson ? `Signed in as ${getFullNamePreferredPerson(authenticatedPerson)}` : 'Please sign in';
       setSuccessLine(success);
-      setAppContextValue('loggedInPersonIsAdmin', dataAuth.loggedInPersonIsAdmin);
+      // setAppContextValue('loggedInPersonIsAdmin', dataAuth.loggedInPersonIsAdmin);
+      captureAccessRightsData(dataAuth, isSuccessAuth, apiDataCache, dispatch);
       if (isAuthenticated && returnFromLogin) {
         setTimeout(() => {
           navigate('/tasks');
@@ -155,7 +158,8 @@ const Login = ({ classes }) => {
   };
 
   const useSignOutPressed = () => {
-    clearSignedInGlobals(setAppContextValue);
+    // clearSignedInGlobals is also called in logoutApi, so isn't needed here
+    // clearSignedInGlobals(setAppContextValue);
     logoutApi().then();
   };
 

--- a/src/js/pages/SystemSettings/SystemSettings.jsx
+++ b/src/js/pages/SystemSettings/SystemSettings.jsx
@@ -17,13 +17,13 @@ import { captureQuestionnaireListRetrieveData } from '../../models/Questionnaire
 import { captureTaskDefinitionListRetrieveData, captureTaskGroupListRetrieveData, captureTaskStatusListRetrieveData } from '../../models/TaskModel';
 import { METHOD, useFetchData } from '../../react-query/WeConnectQuery';
 import PermissionsAdministration from './PermissionsAdministration';
+import { viewerCanSeeOrDo } from '../../models/AuthModel';
 
 
 const SystemSettings = ({ classes }) => {
   renderLog('SystemSettings');
-  const { setAppContextValue } = useConnectAppContext();
-  const { apiDataCache } = useConnectAppContext();
-  const { allPeopleCache, allTaskGroupsCache, allQuestionnairesCache } = apiDataCache;
+  const { apiDataCache, setAppContextValue } = useConnectAppContext();
+  const { viewerAccessRights, allPeopleCache, allTaskGroupsCache, allQuestionnairesCache } = apiDataCache;
   const dispatch = useConnectDispatch();
 
   const [personIdsList, setPersonIdsList] = useState([]);
@@ -119,6 +119,14 @@ const SystemSettings = ({ classes }) => {
 
     navigate(`/questionnaire/${questionnaire.questionnaireId}`);
   };
+
+  if (!viewerCanSeeOrDo('canViewSystemSettings', viewerAccessRights)) {
+    return (
+      <PageContentContainer>
+        <h1>You do not have permission to access this page.</h1>
+      </PageContentContainer>
+    );
+  }
 
   return (
     <div>

--- a/src/js/pages/Teams.jsx
+++ b/src/js/pages/Teams.jsx
@@ -15,16 +15,15 @@ import { useConnectAppContext, useConnectDispatch } from '../contexts/ConnectApp
 import { isSearchTextFoundInPerson } from '../controllers/PersonController';
 import { isSearchTextFoundInTeam } from '../controllers/TeamController';
 import capturePersonListRetrieveData from '../models/capturePersonListRetrieveData';
+import { viewerCanSeeOrDo } from '../models/AuthModel';
 import { captureTeamListRetrieveData, getTeamMembersListByTeamId } from '../models/TeamModel';
 import { METHOD, useFetchData } from '../react-query/WeConnectQuery';
 
 
-// eslint-disable-next-line no-unused-vars
 const Teams = () => {
   renderLog('Teams');
-  const { setAppContextValue, getAppContextValue } = useConnectAppContext();
-  const { apiDataCache } = useConnectAppContext();
-  const { allPeopleCache, allTeamsCache } = apiDataCache;
+  const { apiDataCache, setAppContextValue, getAppContextValue } = useConnectAppContext();
+  const { viewerAccessRights, allPeopleCache, allTeamsCache } = apiDataCache;
   const dispatch = useConnectDispatch();
 
   const [searchText, setSearchText] = useState('');
@@ -166,16 +165,20 @@ const Teams = () => {
             </ActionBarItem>
           </ActionBarSection>
           <ActionBarSection>
-            <ActionBarItem>
-              <SpanWithLinkStyle onClick={() => addTeamClick()}>
-                Add team
-              </SpanWithLinkStyle>
-            </ActionBarItem>
-            <ActionBarItem>
-              <SpanWithLinkStyle onClick={() => addTeamMemberClick()}>
-                Add team member
-              </SpanWithLinkStyle>
-            </ActionBarItem>
+            {viewerCanSeeOrDo('canAddTeam', viewerAccessRights) && (
+              <ActionBarItem>
+                <SpanWithLinkStyle onClick={() => addTeamClick()}>
+                  Add team
+                </SpanWithLinkStyle>
+              </ActionBarItem>
+            )}
+            {viewerCanSeeOrDo('canAddTeamMemberAnyTeam', viewerAccessRights) && (
+              <ActionBarItem>
+                <SpanWithLinkStyle onClick={() => addTeamMemberClick()}>
+                  Add team member
+                </SpanWithLinkStyle>
+              </ActionBarItem>
+            )}
           </ActionBarSection>
         </ActionBarWrapper>
         {/* NOTE: we had discussed refactoring team-list-retrieve to not include person data, */}

--- a/src/js/react-query/WeConnectQuery.js
+++ b/src/js/react-query/WeConnectQuery.js
@@ -25,6 +25,11 @@ const weConnectQueryFn = async (queryKey, params, isGet) => {
       await axios.get(url.href, { withCredentials: true }) :
       await axios.post(url.href, params, { withCredentials: true });
     // if needed:  httpLog('weConnectQueryFn  response.data: ', JSON.stringify(response.data));
+    // console.log('weConnectQueryFn response.status: ', response.status, ', response.data: ', JSON.stringify(response.data) || 'No data');
+    if (response.data.displayErrorMessage) {
+      // TODO Consider showing this API error in the interface to the viewer
+      console.error(`displayErrorMessage ${queryKey} status: ${response.data.status}`);
+    }
   } catch (e) {
     console.error('Axios ', (isGet ? 'axios.get' : 'axios.post'), ' error: ', e);
   }


### PR DESCRIPTION
First pass on viewerCanSeeOrDo & viewerAccessRights implementation. Added finer-grained viewerCanSeeOrDo switch to PersonSummaryRow & TeamHeader, so we turn off interface elements the person cannot access. Tested signin/signout, and confirmed that is still working. Registration requires manual browser refresh for signed in access rights to be recognized. Replaced loggedInPersonIsAdmin with viewerCanSeeOrDo & viewerAccessRights implementation. Control which PersonProfile we want to show with incoming prop. Working on bringing QuestionnaireResponsesList back to life. Implemented models/PersonModel - capturePersonRetrieveData. We may decide not to use person-retrieve in the future but I'd like to leave in place.