### PR TITLE
Added TasksDataRetrieve to App.jsx so we have all the tasks data we need for the HeaderProfileDrawer. Moved TeamMemberList inside TeamHeader in order to simplify opening and closing a team row on the Teams page. Started building out the expand/collapse logic to match latest designs on the Teams page. Adjusting spacing of Person-related column headers. Still a work in progress.

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import { normalizedHref } from './js/common/utils/hrefUtils';
 import initializejQuery from './js/common/utils/initializejQuery';
 import { renderLog } from './js/common/utils/logging';
 import Drawers from './js/components/Drawers/Drawers';
+import TasksDataRetrieve from './js/components/Task/TasksDataRetrieve';
 import PrivateRoute from './js/components/PrivateRoute';
 import webAppConfig from './js/config';
 import ConnectAppContext from './js/contexts/ConnectAppContext';
@@ -92,6 +93,7 @@ function App () {
                     </Route>
                     <Route path="*" element={<PageNotFound />} />
                   </Routes>
+                  <TasksDataRetrieve />
                   {/* <Footer /> has problems */}
                   {showDevtools && (
                     <ReactQueryDevtools />

--- a/src/js/components/Person/PersonSummaryHeader.jsx
+++ b/src/js/components/Person/PersonSummaryHeader.jsx
@@ -8,15 +8,14 @@ const PersonSummaryHeader = () => {
 
   return (
     <OnePersonHeader>
-      {/* Width (below) of this PersonHeaderCell comes from the combined widths of the first x columns in PersonMemberList */}
-      <PersonHeaderCell $largefont $titleCell $cellwidth={250}>
-        &nbsp;
+      <PersonHeaderCell $cellwidth={180}>
+        Name
       </PersonHeaderCell>
-      <PersonHeaderCell $cellwidth={300}>
+      <PersonHeaderCell $cellwidth={150}>
         Location
       </PersonHeaderCell>
-      <PersonHeaderCell $cellwidth={300}>
-        Title / Volunteering Love
+      <PersonHeaderCell $cellwidth={200}>
+        Title
       </PersonHeaderCell>
       {/* Edit icon */}
       <PersonHeaderCell $cellwidth={20} />
@@ -36,7 +35,6 @@ const PersonHeaderCell = styled.div`
   align-content: center;
   height: 22px;
   font-size: ${(props) => (props?.$largefont ? '1.1em;' : '.8em;')};
-  font-weight: ${(props) => (props?.$titleCell ? ';' : '550;')}
   min-width: ${(props) => (props.$cellwidth ? `${props.$cellwidth}px;` : ';')};
   max-width: ${(props) => (props.$cellwidth ? `${props.$cellwidth}px;` : ';')};
   width: ${(props) => (props.$cellwidth ? `${props.$cellwidth}px;` : ';')};

--- a/src/js/components/Person/PersonSummaryRow.jsx
+++ b/src/js/components/Person/PersonSummaryRow.jsx
@@ -82,21 +82,21 @@ const PersonSummaryRow = ({ person, rowNumberForDisplay, teamId }) => {
           textDecoration: 'underline',
           color: DesignTokenColors.primary500,
         }}
-        $cellwidth={250}
+        $cellwidth={180}
       >
         {/* {`${person.firstName} ${person.lastName}`} */}
         {getFullNamePreferredPerson(person)} {/* 2/6/25 currently if you save a first name preferred, it shows up here, but will not be searchable on add team member If you */}
       </PersonCell>
       <PersonCell
         id={`location-personId-${person.personId}`}
-        $cellwidth={300}
+        $cellwidth={150}
         $smallfont
       >
         {person.location}
       </PersonCell>
       <PersonCell
         id={`jobTitle-personId-${person.personId}`}
-        $cellwidth={300}
+        $cellwidth={200}
         $smallestfont
       >
         {person.jobTitle}

--- a/src/js/components/Task/TasksDataRetrieve.jsx
+++ b/src/js/components/Task/TasksDataRetrieve.jsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useState } from 'react';
+import { renderLog } from '../../common/utils/logging';
+import { useConnectAppContext, useConnectDispatch } from '../../contexts/ConnectAppContext';
+import capturePersonListRetrieveData from '../../models/capturePersonListRetrieveData';
+import {
+  captureTaskDefinitionListRetrieveData, captureTaskGroupListRetrieveData, captureTaskStatusListRetrieveData,
+} from '../../models/TaskModel';
+import { captureTeamListRetrieveData } from '../../models/TeamModel';
+import { METHOD, useFetchData } from '../../react-query/WeConnectQuery';
+
+
+// We need the task data, coming from a few API calls, in the HeaderProfileDrawer.
+//  Since the HeaderProfileDrawer can be opened from a variety of root pages,
+//  we include this component in the App component.
+const TasksDataRetrieve = () => {
+  renderLog('TasksDataRetrieve');  // Set LOG_RENDER_EVENTS to log all renders
+  const { apiDataCache } = useConnectAppContext();
+  const { allPeopleCache } = apiDataCache;
+  const dispatch = useConnectDispatch();
+
+  const [personIdsList, setPersonIdsList] = useState([]);
+
+  const personListRetrieveResults = useFetchData(['person-list-retrieve'], {}, METHOD.GET);
+  useEffect(() => {
+    if (personListRetrieveResults) {
+      capturePersonListRetrieveData(personListRetrieveResults, apiDataCache, dispatch);
+    }
+  }, [personListRetrieveResults, allPeopleCache, dispatch]);
+
+  const taskDefinitionListRetrieveResults = useFetchData(['task-definition-list-retrieve'], {}, METHOD.GET);
+  useEffect(() => {
+    if (taskDefinitionListRetrieveResults) {
+      captureTaskDefinitionListRetrieveData(taskDefinitionListRetrieveResults, apiDataCache, dispatch);
+    }
+  }, [apiDataCache, dispatch, taskDefinitionListRetrieveResults]);
+
+  const taskGroupListRetrieveResults = useFetchData(['task-group-list-retrieve'], {}, METHOD.GET);
+  useEffect(() => {
+    if (taskGroupListRetrieveResults) {
+      captureTaskGroupListRetrieveData(taskGroupListRetrieveResults, apiDataCache, dispatch);
+    }
+  }, [apiDataCache, dispatch, taskGroupListRetrieveResults]);
+
+  const taskStatusListRetrieveResults = useFetchData(['task-status-list-retrieve'], { personIdList: personIdsList }, METHOD.GET);
+  useEffect(() => {
+    if (taskStatusListRetrieveResults) {
+      captureTaskStatusListRetrieveData(taskStatusListRetrieveResults, apiDataCache, dispatch);
+    }
+  }, [personIdsList, taskStatusListRetrieveResults]);
+
+  const teamListRetrieveResults = useFetchData(['team-list-retrieve'], {}, METHOD.GET);
+  useEffect(() => {
+    if (teamListRetrieveResults) {
+      captureTeamListRetrieveData(teamListRetrieveResults, apiDataCache, dispatch);
+    }
+  }, [teamListRetrieveResults]);
+
+  useEffect(() => {
+    // console.log('TasksDataRetrieve useEffect allPeopleCache:', allPeopleCache);
+    if (allPeopleCache) {
+      const allCachedPeopleList = Object.values(allPeopleCache);
+      setPersonIdsList(allCachedPeopleList.map((person) => person.personId));
+    }
+  }, [allPeopleCache]);
+
+  return (
+    <span />
+  );
+};
+
+export default TasksDataRetrieve;

--- a/src/js/components/Team/TeamHeader.jsx
+++ b/src/js/components/Team/TeamHeader.jsx
@@ -1,19 +1,23 @@
+import { KeyboardArrowDown, KeyboardArrowUp } from '@mui/icons-material';
 import { withStyles } from '@mui/styles';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router';
 import styled from 'styled-components';
 import { renderLog } from '../../common/utils/logging';
 import { useConnectAppContext } from '../../contexts/ConnectAppContext';
 import { viewerCanSeeOrDo } from '../../models/AuthModel';
 import { EditStyled } from '../Style/iconStyles';
+import TeamMemberList from './TeamMemberList';
 
 
-const TeamHeader = ({ showHeaderLabels, showIcons, team }) => {
+const TeamHeader = ({ hideInactive, searchText, showAllTeamMembersFromParent, showIcons, team }) => {
   renderLog('TeamHeader');
   const { apiDataCache, getAppContextValue, setAppContextValue } = useConnectAppContext();
   const { viewerAccessRights } = apiDataCache;
 
+  const [showAllTeamMembers, setShowAllTeamMembers] = useState(showAllTeamMembersFromParent);
+  const [showAllTeamMembersFromParentAlreadySet, setShowAllTeamMembersFromParentAlreadySet] = useState(showAllTeamMembersFromParent);
   let teamLocal = team;
   if (!teamLocal || !teamLocal.teamName) {
     teamLocal = getAppContextValue('teamForAddTeamDrawer');
@@ -26,44 +30,87 @@ const TeamHeader = ({ showHeaderLabels, showIcons, team }) => {
     setAppContextValue('teamForAddTeamDrawer', teamLocal);
   };
 
+  useEffect(() => {
+    if (showAllTeamMembersFromParent !== showAllTeamMembersFromParentAlreadySet) {
+      setShowAllTeamMembers(showAllTeamMembersFromParent);
+      setShowAllTeamMembersFromParentAlreadySet(showAllTeamMembersFromParent);
+    }
+  }, [showAllTeamMembers, showAllTeamMembersFromParent, showAllTeamMembersFromParentAlreadySet]);
+
   // console.log('TeamHeader teamLocal.teamName ', teamLocal.teamName);
   return (
-    <OneTeamHeader>
-      {/* Width (below) of this TeamHeaderCell comes from the combined widths of the first x columns in TeamMemberList */}
-      <TeamHeaderCell $cellwidth={showHeaderLabels ? 215 : 500} $largefont $titlecell>
-        {teamLocal && (
-          <Link to={`/team-home/${teamLocal.id}`}>
-            {teamLocal.teamName}
-          </Link>
-        )}
-      </TeamHeaderCell>
-      <TeamHeaderCell $cellwidth={showHeaderLabels ? 300 : 15}>
-        {showHeaderLabels ? 'Location' : ''}
-      </TeamHeaderCell>
-      <TeamHeaderCell $cellwidth={360}>
-        {showHeaderLabels ? 'Title / Volunteering Love' : ''}
-      </TeamHeaderCell>
-      {/* Edit icon */}
-      {showIcons && (
-        <>
-          {viewerCanSeeOrDo('canEditTeamAnyTeam', viewerAccessRights) && (
-            <TeamHeaderCell $cellwidth={20} onClick={editTeamClick}>
-              <EditStyled />
+    <OneTeamOuterWrapper>
+      <OneTeamHeaderOuterWrapper>
+        <TeamHeaderMainRow>
+          <TeamHeaderCell
+            onClick={() => setShowAllTeamMembers(!showAllTeamMembers)}
+            $cellwidth={25}
+            $titlecell
+          >
+            {showAllTeamMembers ? (
+              <KeyboardArrowUpStyled />
+            ) : (
+              <KeyboardArrowDownStyled />
+            )}
+          </TeamHeaderCell>
+          <TeamHeaderCell $cellwidth={showAllTeamMembers ? 215 : 500} $largefont $titlecell>
+            {teamLocal && (
+              <Link to={`/team-home/${teamLocal.id}`}>
+                {teamLocal.teamName}
+              </Link>
+            )}
+          </TeamHeaderCell>
+        </TeamHeaderMainRow>
+        {showAllTeamMembers && (
+          <TeamHeaderPersonColumnTitles>
+            {/* Width (below) of this TeamHeaderCell comes from the combined widths of the first x columns in TeamMemberList */}
+            <TeamHeaderCell $cellwidth={25} />
+            <TeamHeaderCell $cellwidth={180}>
+              Name
             </TeamHeaderCell>
-          )}
+            <TeamHeaderCell $cellwidth={150}>
+              Location
+            </TeamHeaderCell>
+            <TeamHeaderCell $cellwidth={200}>
+              Title
+            </TeamHeaderCell>
+            {/* Edit icon */}
+            {showIcons && (
+              <>
+                {viewerCanSeeOrDo('canEditTeamAnyTeam', viewerAccessRights) && (
+                  <TeamHeaderCell $cellwidth={20} onClick={editTeamClick}>
+                    <EditStyled />
+                  </TeamHeaderCell>
+                )}
+              </>
+            )}
+            {/* Delete icon - Moved to TeamHome */}
+            {showIcons && (
+              <></>
+            )}
+          </TeamHeaderPersonColumnTitles>
+        )}
+      </OneTeamHeaderOuterWrapper>
+      {showAllTeamMembers && (
+        <>
+          {/* DO NOT REMOVE PASSED IN team */}
+          <TeamMemberList
+            searchText={searchText}
+            team={team}
+            teamId={team.id}
+            hideInactive={hideInactive}
+          />
         </>
       )}
-      {/* Delete icon - Moved to TeamHome */}
-      {showIcons && (
-        <></>
-      )}
-    </OneTeamHeader>
+    </OneTeamOuterWrapper>
   );
 };
 TeamHeader.propTypes = {
-  showHeaderLabels: PropTypes.bool,
-  team: PropTypes.object,
+  hideInactive: PropTypes.bool,
+  searchText: PropTypes.bool,
   showIcons: PropTypes.bool,
+  showAllTeamMembersFromParent: PropTypes.bool,
+  team: PropTypes.object,
 };
 
 const styles = (theme) => ({
@@ -78,7 +125,26 @@ const styles = (theme) => ({
   },
 });
 
-const OneTeamHeader = styled('div')`
+const KeyboardArrowDownStyled = styled(KeyboardArrowDown)`
+`;
+
+const KeyboardArrowUpStyled = styled(KeyboardArrowUp)`
+`;
+
+const OneTeamHeaderOuterWrapper = styled('div')`
+`;
+
+const OneTeamOuterWrapper = styled('div')`
+`;
+
+const TeamHeaderMainRow = styled('div')`
+  align-items: center;
+  display: flex;
+  justify-content: flex-start;
+  margin-top: 10px;
+`;
+
+const TeamHeaderPersonColumnTitles = styled('div')`
   align-items: center;
   display: flex;
   justify-content: flex-start;
@@ -89,7 +155,6 @@ const TeamHeaderCell = styled.div`
   align-content: center;
   border-bottom: ${(props) => (props?.$titleCell ? ';' : '1px solid #ccc;')}
   font-size: ${(props) => (props?.$largefont ? '1.1em;' : '.8em;')};
-  font-weight: ${(props) => (props?.$titleCell ? ';' : '550;')}
   height: 22px;
   max-width: ${(props) => (props.$cellwidth ? `${props.$cellwidth}px;` : ';')};
   min-width: ${(props) => (props.$cellwidth ? `${props.$cellwidth}px;` : ';')};

--- a/src/js/pages/Tasks.jsx
+++ b/src/js/pages/Tasks.jsx
@@ -1,5 +1,4 @@
 import { withStyles } from '@mui/styles';
-import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import styled from 'styled-components';
@@ -25,8 +24,7 @@ import { METHOD, useFetchData } from '../react-query/WeConnectQuery';
 import { alphabetizePeoplesObject } from '../utils/utilities';
 
 
-// eslint-disable-next-line no-unused-vars
-const Tasks = ({ classes, match }) => {
+const Tasks = () => {
   renderLog('Tasks');  // Set LOG_RENDER_EVENTS to log all renders
   const { apiDataCache, setAppContextValue } = useConnectAppContext();
   const { allPeopleCache, allTaskDefinitionsCache, allTasksCache, viewerAccessRights } = apiDataCache;
@@ -227,11 +225,6 @@ const Tasks = ({ classes, match }) => {
       </PageContentContainer>
     </div>
   );
-};
-Tasks.propTypes = {
-  classes: PropTypes.object.isRequired,
-  // match: PropTypes.object.isRequired,
-  match: PropTypes.object,
 };
 
 const styles = (theme) => ({

--- a/src/js/pages/TeamHome.jsx
+++ b/src/js/pages/TeamHome.jsx
@@ -11,7 +11,6 @@ import { ActionBarItem, ActionBarSection } from '../components/Style/actionBarSt
 import { SpanWithLinkStyle } from '../components/Style/linkStyles';
 import { PageContentContainer } from '../components/Style/pageLayoutStyles';
 import TeamHeader from '../components/Team/TeamHeader';
-import TeamMemberList from '../components/Team/TeamMemberList';
 import webAppConfig from '../config';
 import { useConnectAppContext, useConnectDispatch } from '../contexts/ConnectAppContext';
 import { viewerCanSeeOrDo } from '../models/AuthModel';
@@ -128,15 +127,9 @@ const TeamHome = ({ classes }) => {
           <>
             <TeamHeader
               team={team}
-              showHeaderLabels
-              // showHeaderLabels={(teamMemberList && teamMemberList.length > 0)}
+              showAllTeamMembersFromParent
+              // showAllTeamMembers={(teamMemberList && teamMemberList.length > 0)}
               showIcons={false}
-            />
-            {/* PLEASE DO NOT REMOVE PASSED team */}
-            <TeamMemberList
-              hideInactive={hideInactive}
-              team={team}
-              teamId={teamId}
             />
           </>
         )}

--- a/src/js/pages/Teams.jsx
+++ b/src/js/pages/Teams.jsx
@@ -9,7 +9,6 @@ import { ActionBarItem, ActionBarSection, SearchBarWrapper } from '../components
 import { SpanWithLinkStyle } from '../components/Style/linkStyles';
 import { PageContentContainer } from '../components/Style/pageLayoutStyles';
 import TeamHeader from '../components/Team/TeamHeader';
-import TeamMemberList from '../components/Team/TeamMemberList';
 import webAppConfig from '../config';
 import { useConnectAppContext, useConnectDispatch } from '../contexts/ConnectAppContext';
 import { isSearchTextFoundInPerson } from '../controllers/PersonController';
@@ -189,26 +188,17 @@ const Teams = () => {
         </TeamsActionBarWrapper>
         {/* NOTE: we had discussed refactoring team-list-retrieve to not include person data, */}
         {/* so that team.teamMemberList would only include the personIds of team members */}
-        {teamList.map((team, index) => {
+        {teamList.map((team) => {
           if (showTeam(team)) {
             return (
               <OneTeamWrapper key={`team-${team.id}`}>
                 <TeamHeader
-                  team={team}
-                  showHeaderLabels={(index === 0) && showAllTeamMembers && (team.teamMemberList && team.teamMemberList.length > 0)}
+                  hideInactive={hideInactive}
+                  searchText={searchText}
+                  showAllTeamMembersFromParent={showAllTeamMembers}
                   showIcons
+                  team={team}
                 />
-                {showAllTeamMembers && (
-                  <>
-                    {/* DO NOT REMOVE PASSED IN team */}
-                    <TeamMemberList
-                      searchText={searchText}
-                      team={team}
-                      teamId={team.id}
-                      hideInactive={hideInactive}
-                    />
-                  </>
-                )}
               </OneTeamWrapper>
             );
           } else {


### PR DESCRIPTION
Added TasksDataRetrieve to App.jsx so we have all the tasks data we need for the HeaderProfileDrawer. Moved TeamMemberList inside TeamHeader in order to simplify opening and closing a team row on the Teams page. Started building out the expand/collapse logic to match latest designs on the Teams page. Adjusting spacing of Person-related column headers. Still a work in progress.