### PR TITLE
Intermediate Checkin for PermissionsAdministration fixes/improvements

### DIFF
--- a/src/js/components/Navigation/TasksActionBar.jsx
+++ b/src/js/components/Navigation/TasksActionBar.jsx
@@ -9,7 +9,7 @@ import { viewerCanSeeOrDo } from '../../models/AuthModel';
 
 
 const TasksActionBar = () => {
-  renderLog('TasksActionBar');  // Set LOG_RENDER_EVENTS to log all renders
+  renderLog('TasksActionBar');
   const { apiDataCache, getAppContextValue, setAppContextValue } = useConnectAppContext();
   const { viewerAccessRights } = apiDataCache;
 

--- a/src/js/components/Navigation/TeamsActionBar.jsx
+++ b/src/js/components/Navigation/TeamsActionBar.jsx
@@ -49,7 +49,7 @@ const TeamsActionBar = () => {
     setAppContextValue('AddPersonDrawerLabel', 'Add Person');
   };
 
-  // const hideInactiveClick = () => {
+  //  const hideInactiveClick = () => {
   //   setHideInactive(!hideInactive);
   // };
 

--- a/src/js/components/Style/actionBarStyles.js
+++ b/src/js/components/Style/actionBarStyles.js
@@ -30,3 +30,4 @@ export const DetailsRowSection = styled('div')`
 export const SearchBarWrapper = styled('div')`
   margin-right: 10px;
 `;
+

--- a/src/js/pages/SystemSettings/PermissionsAdministration.jsx
+++ b/src/js/pages/SystemSettings/PermissionsAdministration.jsx
@@ -363,7 +363,7 @@ const PermissionsAdministration = ({ classes }) => {
                 Show All
               </Button>
             </Th>
-            <Th $cellwidth={25}></Th>
+            <Th $cellwidth={25} />
           </tr>
         </thead>
         <tbody>

--- a/src/js/pages/SystemSettings/PermissionsAdministration.jsx
+++ b/src/js/pages/SystemSettings/PermissionsAdministration.jsx
@@ -25,6 +25,7 @@ const PermissionsAdministration = ({ classes }) => {
   const [peopleWorkingArrayFiltered, setPeopleWorkingArrayFiltered] = useState(); // Object.values(allPeopleCacheCopy1));
   const [updateCount, setUpdateCount] = useState(0);
   const [canEditPermissionsAnyone, setCanEditPermissionsAnyone] = useState(false);
+  const [dummyCounter, setDummyCounter] = useState(0);
 
   const searchByNameRef = useRef('');
   const filterState = useRef({});
@@ -226,6 +227,19 @@ const PermissionsAdministration = ({ classes }) => {
     }
   };
 
+  const showAll  = () => {
+    resetFilterButtons();
+    resetOnlyButtons();
+    filterState.current.leave = true;
+    filterState.current.resigned = true;
+    filterState.current.special = true;
+    const allPeopleCacheCopy2 = JSON.parse(JSON.stringify(allPeopleCache));
+    const sorted = alphabetizePeoplesObject(allPeopleCacheCopy2);
+    sorted.forEach((person) => setStatusFieldsIfNotInitialized(person));
+    setPeopleWorkingArray(sorted);
+    setPeopleWorkingArrayFiltered(sorted.filter((person) => includePersonInFilteredArray(person)));
+  };
+
   const searchAndFilterFunction = (event) => {
     let { id } = event.currentTarget;
     if (id.includes('Filter')) {
@@ -334,8 +348,22 @@ const PermissionsAdministration = ({ classes }) => {
             <TableHeaderButton id="leaveFilter" text="Leave" />
             <TableHeaderButton id="resignedFilter" text="Resigned" />
             <TableHeaderButton id="specialFilter" text="Special Projects" />
-            <Th $cellwidth={25}>{peopleWorkingArrayFiltered?.length} Staff</Th>
-            <Th $cellwidth={25}>&nbsp;</Th>
+            <Th $cellwidth={25}>
+              <div style={{ width: '100px' }}>
+                {peopleWorkingArrayFiltered?.length} Staff
+              </div>
+              <Button
+                variant="outlined"
+                id="AllButton"
+                size="small"
+                onClick={showAll}
+                state
+                sx={{ transform: 'translate(-4%,114%)' }}
+              >
+                All
+              </Button>
+            </Th>
+            <Th $cellwidth={25}></Th>
           </tr>
         </thead>
         <tbody>

--- a/src/js/pages/SystemSettings/PermissionsAdministration.jsx
+++ b/src/js/pages/SystemSettings/PermissionsAdministration.jsx
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { renderLog } from '../../common/utils/logging';
-import { SearchBarWrapper } from '../../components/Style/sharedStyles';
 import { useConnectAppContext } from '../../contexts/ConnectAppContext';
 import { viewerCanSeeOrDo } from '../../models/AuthModel';
 import { getFullNamePreferredPerson } from '../../models/PersonModel';
@@ -28,19 +27,8 @@ const PermissionsAdministration = ({ classes }) => {
   const [canEditPermissionsAnyone, setCanEditPermissionsAnyone] = useState(false);
 
   const searchByNameRef = useRef('');
-  const filterState = useRef({
-    admin: true,
-    hrOfferAdmin: true,
-    hrAdmin: true,
-    hrGen1: true,
-    hrGen2: true,
-    hiring: true,
-    lead: true,
-    intern: true,
-    active: true,
-    leave: false,
-    resigned: false,
-  });
+  const filterState = useRef({});
+  const onlyState = useRef({});
   const adminInputRef = useRef();
   const hrOfferAdminInputRef = useRef();
   const hrAdminInputRef = useRef();
@@ -52,6 +40,7 @@ const PermissionsAdministration = ({ classes }) => {
   const activeInputRef = useRef();
   const leaveInputRef = useRef();
   const resignedInputRef = useRef();
+  const specialInputRef = useRef();
 
   useEffect(() => {
     setCanEditPermissionsAnyone(viewerCanSeeOrDo(['canEditPermissionsAnyone'], viewerAccessRights));
@@ -62,23 +51,100 @@ const PermissionsAdministration = ({ classes }) => {
     DISABLE: false,
   };
 
+  const resetFilterButtons = () => {
+    filterState.current.admin = true;
+    filterState.current.hrOfferAdmin = true;
+    filterState.current.hrAdmin = true;
+    filterState.current.hrGen1 = true;
+    filterState.current.hrGen2 = true;
+    filterState.current.hiring = true;
+    filterState.current.lead = true;
+    filterState.current.intern = true;
+    filterState.current.active = true;
+    filterState.current.leave = false;       // Defaults to false, since it is rarely used
+    filterState.current.resigned = false;    // Defaults to false, since it is rarely used
+    filterState.current.special = false;     // Defaults to false, since it is rarely used
+  };
+
+  const resetOnlyButtons = () => {
+    onlyState.current.admin = false;
+    onlyState.current.hrOfferAdmin = false;
+    onlyState.current.hrAdmin = false;
+    onlyState.current.hrGen1 = false;
+    onlyState.current.hrGen2 = false;
+    onlyState.current.hiring = false;
+    onlyState.current.lead = false;
+    onlyState.current.intern = false;
+    onlyState.current.active = false;
+    onlyState.current.leave = false;
+    onlyState.current.resigned = false;
+    onlyState.current.special = false;
+  };
+
+  useEffect(() => {
+    resetFilterButtons();
+    resetOnlyButtons();
+  }, []);
+
+
+  const setStatusFieldsIfNotInitialized = (person) => {
+    /* eslint-disable no-param-reassign */
+    if (person.isAdmin === null) person.isAdmin = false;
+    if (person.isHiringManager === null) person.isHiringManager = false;
+    if (person.isIntern === null) person.isIntern = false;
+    if (person.isTeamLead === null) person.isTeamLead = false;
+    if (person.statusEmailCreated === null) person.statusEmailCreated = false;
+    if (person.statusActive === null) person.statusActive = true;
+    if (person.statusOfferLetterCreated === null) person.statusOfferLetterCreated = false;
+    if (person.statusOfferLetterSigned === null) person.statusOfferLetterSigned = false;
+    if (person.statusOnLeave === null) person.statusOnLeave = false;
+    if (person.statusResigned === null) person.statusResigned = false;
+    if (person.statusNonresponsive === null) person.statusNonresponsive = false;
+    if (person.statusOfferApproved === null) person.statusOfferApproved = false;
+    if (person.statusOfferWillNotBeMade === null) person.statusOfferWillNotBeMade = false;
+    if (person.isHRAdmin === null) person.isHRAdmin = false;
+    if (person.isHRGeneralist1 === null) person.isHRGeneralist1 = false;
+    if (person.isHRGeneralist2 === null) person.isHRGeneralist2 = false;
+    if (person.isHROfferAdmin === null) person.isHROfferAdmin = false;
+    if (person.statusAvailableForSpecialProjects === null) person.statusAvailableForSpecialProjects = false;
+    /* eslint-enable no-param-reassign */
+  };
+
+
   const includePersonInFilteredArray = (person) => {
-    if (person.isAdmin === true && filterState.current.admin === false) return false;
-    if (person.isHROfferAdmin === true && filterState.current.hrOfferAdmin === false) return false;
-    if (person.isHRAdmin === true && filterState.current.hrAdmin === false) return false;
-    if (person.isHRGeneralist1 === true && filterState.current.hrGen1 === false) return false;
-    if (person.isHRGeneralist2 === true && filterState.current.hrGen2 === false) return false;
-    if (person.isHiringManager === true && filterState.current.hiring === false) return false;
-    if (person.isTeamLead === true && filterState.current.lead === false) return false;
-    if (person.isIntern === true && filterState.current.intern === false) return false;
-    if (person.statusActive === true && filterState.current.active === false) return false;
-    if (person.statusOnLeave === true && filterState.current.leave === false) return false;
-    return !(person.statusResigned === true && filterState.current.resigned === false);
+    const include = (person.isAdmin === true && filterState.current.admin === true) ||
+      (person.isHROfferAdmin === true && filterState.current.hrOfferAdmin === true) ||
+      (person.isHRAdmin === true && filterState.current.hrAdmin === true) ||
+      (person.isHRGeneralist1 === true && filterState.current.hrGen1 === true) ||
+      (person.isHRGeneralist2 === true && filterState.current.hrGen2 === true) ||
+      (person.isHiringManager === true && filterState.current.hiring === true) ||
+      (person.isTeamLead === true && filterState.current.lead === true) ||
+      (person.isIntern === true && filterState.current.intern === true) ||
+      (person.statusActive === true && filterState.current.active === true) ||
+      (person.statusOnLeave === true && filterState.current.leave === true) ||
+      (person.statusResigned === true && filterState.current.resigned === true) ||
+      (person.statusAvailableForSpecialProjects === true && filterState.current.special === true);
+    // Show them if none of the is/status are true, and all of the filterStates are true
+    const zero = person.isAdmin === false && filterState.current.admin === true &&
+      person.isHROfferAdmin === false && filterState.current.hrOfferAdmin === true &&
+      person.isHRAdmin === false && filterState.current.hrAdmin === true &&
+      person.isHRGeneralist1 === false && filterState.current.hrGen1 === true &&
+      person.isHRGeneralist2 === false && filterState.current.hrGen2 === true &&
+      person.isHiringManager === false && filterState.current.hiring === true &&
+      person.isTeamLead === false && filterState.current.lead === true &&
+      person.isIntern === false && filterState.current.intern === true &&
+      person.statusActive === false && filterState.current.active === true &&
+      person.statusOnLeave === false && filterState.current.leave === true &&
+      person.statusResigned === false && filterState.current.resigned === true &&
+      person.statusAvailableForSpecialProjects === false && filterState.current.special === true;
+
+    return include || zero;
   };
 
   useEffect(() => {
     const allPeopleCacheCopy2 = JSON.parse(JSON.stringify(allPeopleCache));
     const sorted = alphabetizePeoplesObject(allPeopleCacheCopy2);
+    sorted.forEach((person) => setStatusFieldsIfNotInitialized(person));
     setPeopleWorkingArray(sorted);
     setPeopleWorkingArrayFiltered(sorted.filter((person) => includePersonInFilteredArray(person)));
   }, [allPeopleCache]);
@@ -149,6 +215,7 @@ const PermissionsAdministration = ({ classes }) => {
         case 'active':       person.statusActive = event.target.checked; break;
         case 'leave':        person.statusOnLeave = event.target.checked; break;
         case 'resigned':     person.statusResigned = event.target.checked; break;
+        case 'special':      person.statusAvailableForSpecialProjects = event.target.checked; break;
         default:
           console.log('ERROR onClickCheckbox received invalid target id: ', event.target.id);
           return;
@@ -165,9 +232,29 @@ const PermissionsAdministration = ({ classes }) => {
       // Update filterState array
       id = id.replace('Filter', '');
       const element = Object.entries(filterState.current).find((key) => key[0] === id);
-      console.log('filter clicked: ', id);
       filterState.current[element[0]] = !element[1];
-      console.log('filter clicked: ', element);
+      resetOnlyButtons();
+    } else if (id.includes('Only')) {
+      id = id.replace('Only', '');
+      Object.keys(onlyState.current).forEach((key) => {
+        if (key === id) {
+          // key for the 'only' button that was clicked
+          if (onlyState.current[key]) {
+            // If the button is already selected, then we are deselecting
+            onlyState.current[key] = false;
+            resetFilterButtons();
+            resetOnlyButtons();
+          } else {
+            // The clicked button is not already selected
+            Object.keys(filterState.current).forEach((keySelect) => {
+              // Iterate through all the filter state buttons, and make them match the
+              filterState.current[keySelect] = keySelect === id;
+              onlyState.current[keySelect] = keySelect === id;
+            });
+          }
+        }
+      });
+      console.log('only filter clicked: ', id);
     }
     // Remove any search limiting from the dataset, but re-add the column filtering
     const filteredPeople = peopleWorkingArray.filter((person) => includePersonInFilteredArray(person));
@@ -186,16 +273,33 @@ const PermissionsAdministration = ({ classes }) => {
     const filterStateKey = id.replace('Filter', '');
     return (
       <Th $cellwidth={25} $padding={false}>
-        <Button id={id} size="small" onClick={searchAndFilterFunction} sx={{ color: filterState.current[filterStateKey] ? '#206DB3;' : 'grey' }}>
-          {text}
-        </Button>
+        <div style={{ marginBottom: '4px' }}>
+          <FilterButton
+            variant="outlined"
+            id={id}
+            size="small"
+            onClick={searchAndFilterFunction}
+            state={filterState.current[filterStateKey]}
+          >
+            {text}
+          </FilterButton>
+        </div>
+        <OnlyButton
+          variant="outlined"
+          id={`${filterStateKey}Only`}
+          size="small"
+          onClick={searchAndFilterFunction}
+          state={onlyState.current[filterStateKey]}
+        >
+          Only
+        </OnlyButton>
       </Th>
     );
   };
 
   return (
     <PermissionsWrapper>
-      <SearchBarWrapper>
+      <PermissionsSearchBarWrapper>
         <TextField
           id="search_input"
           label="Search by name"
@@ -206,7 +310,8 @@ const PermissionsAdministration = ({ classes }) => {
           defaultValue=""
           sx={{ minWidth: '200px', marginRight: '15px' }}
         />
-      </SearchBarWrapper>
+        <span style={{ paddingTop: '33px', color: 'gray' }}>Note: &apos;Leave&apos;, &apos;Resigned&apos;, and &apos;Special Projects&apos; default to off</span>
+      </PermissionsSearchBarWrapper>
       {!canEditPermissionsAnyone && (
         <ErrorText>
           These checkmarks are read-only since you do not have Admin privileges.
@@ -216,7 +321,7 @@ const PermissionsAdministration = ({ classes }) => {
         <thead>
           <tr>
             <Th $cellwidth={250} style={{ textAlign: 'left' }}>Name</Th>
-            <Th $cellwidth={125} style={{ textAlign: 'left' }}>Email</Th>
+            <Th $cellwidth={300} style={{ textAlign: 'left' }}>Email</Th>
             <TableHeaderButton id="adminFilter" text="Admin" />
             <TableHeaderButton id="hrAdminFilter" text="HR Admin" />
             <TableHeaderButton id="hrOfferAdminFilter" text="HR Offer Admin" />
@@ -228,6 +333,7 @@ const PermissionsAdministration = ({ classes }) => {
             <TableHeaderButton id="activeFilter" text="Active" />
             <TableHeaderButton id="leaveFilter" text="Leave" />
             <TableHeaderButton id="resignedFilter" text="Resigned" />
+            <TableHeaderButton id="specialFilter" text="Special Projects" />
             <Th $cellwidth={25}>{peopleWorkingArrayFiltered?.length} Staff</Th>
             <Th $cellwidth={25}>&nbsp;</Th>
           </tr>
@@ -351,6 +457,16 @@ const PermissionsAdministration = ({ classes }) => {
                 />
               </Td>
               <Td>
+                <Checkbox
+                  checked={person.statusAvailableForSpecialProjects}
+                  className={classes.checkboxDoneRoot}
+                  color="primary"
+                  id={`checkbox-special-${person.id}`}
+                  inputRef={specialInputRef}
+                  onChange={onClickCheckbox}
+                />
+              </Td>
+              <Td>
                 {canEditPermissionsAnyone && (
                   <Button id={`person-save-${person.id}`} size="small" onClick={saveClicked}>Save</Button>
                 )}
@@ -414,6 +530,25 @@ const Th = styled.th`
 
 const Td = styled.td`
   text-align: center
+`;
+
+const FilterButton = styled(Button)`
+  height: 100px;
+  display: flex;
+  align-items: center;
+  margin-right: 2px;
+  color: ${(props) => (props.state ? '#206DB3;' : 'grey' )};
+`;
+
+const OnlyButton = styled(Button)`
+  color: ${(props) => (props.state ? '#206DB3;' : 'grey' )};
+`;
+
+const PermissionsSearchBarWrapper = styled('div')`
+  vertical-align:top;
+  margin-bottom: 16px;
+  display: flex;
+  justify-content: space-between;
 `;
 
 export default withStyles(styles)(PermissionsAdministration);

--- a/src/js/pages/SystemSettings/PermissionsAdministration.jsx
+++ b/src/js/pages/SystemSettings/PermissionsAdministration.jsx
@@ -335,7 +335,7 @@ const PermissionsAdministration = ({ classes }) => {
         <thead>
           <tr>
             <Th $cellwidth={250} style={{ textAlign: 'left' }}>Name</Th>
-            <Th $cellwidth={300} style={{ textAlign: 'left' }}>Email</Th>
+            <Th $cellwidth={320} style={{ textAlign: 'left' }}>Email</Th>
             <TableHeaderButton id="adminFilter" text="Admin" />
             <TableHeaderButton id="hrAdminFilter" text="HR Admin" />
             <TableHeaderButton id="hrOfferAdminFilter" text="HR Offer Admin" />
@@ -358,9 +358,9 @@ const PermissionsAdministration = ({ classes }) => {
                 size="small"
                 onClick={showAll}
                 state
-                sx={{ transform: 'translate(-4%,114%)' }}
+                sx={{ transform: 'translate(0,114%)' }}
               >
-                All
+                Show All
               </Button>
             </Th>
             <Th $cellwidth={25}></Th>

--- a/src/js/pages/SystemSettings/SlackSendMessage.jsx
+++ b/src/js/pages/SystemSettings/SlackSendMessage.jsx
@@ -163,6 +163,7 @@ SlackSendMessage.propTypes = {
 const styles = () => ({
 });
 
+
 const ButtonPanel = styled('div')`
   padding: 5px;
   width: fit-content;

--- a/src/js/pages/SystemSettings/SystemSettings.jsx
+++ b/src/js/pages/SystemSettings/SystemSettings.jsx
@@ -145,7 +145,7 @@ const SystemSettings = ({ classes }) => {
         </title>
         <link rel="canonical" href={`${webAppConfig.WECONNECT_URL_FOR_SEO}/system-settings`} />
       </Helmet>
-      <PageContentContainer style={{ maxWidth: '150px' }}>
+      <PageContentContainer style={{ maxWidth: '1500px' }}>
         <h1>
           System Settings
         </h1>

--- a/src/js/pages/SystemSettings/SystemSettings.jsx
+++ b/src/js/pages/SystemSettings/SystemSettings.jsx
@@ -132,7 +132,7 @@ const SystemSettings = ({ classes }) => {
     );
   }
 
-  // Alphabetically sort questionnaires and task groups
+  // Alphabetically sort questionnaires and task  groups
   questionnaireList.sort((a, b) => a.questionnaireName.localeCompare(b.questionnaireName));
   taskGroupList.sort((a, b) => a.taskGroupName.localeCompare(b.taskGroupName));
   return (
@@ -145,7 +145,7 @@ const SystemSettings = ({ classes }) => {
         </title>
         <link rel="canonical" href={`${webAppConfig.WECONNECT_URL_FOR_SEO}/system-settings`} />
       </Helmet>
-      <PageContentContainer style={{ maxWidth: '1200px' }}>
+      <PageContentContainer style={{ maxWidth: '150px' }}>
         <h1>
           System Settings
         </h1>

--- a/src/js/pages/SystemSettings/SystemSettings.jsx
+++ b/src/js/pages/SystemSettings/SystemSettings.jsx
@@ -29,6 +29,7 @@ import SlackGetPresence from './SlackGetPresence';
 import SlackListUsers from './SlackListMembers';
 import SlackSendMessage from './SlackSendMessage';
 import UploadCSV from './UploadCSV';
+import SouthIcon from '@mui/icons-material/South';
 
 
 const SystemSettings = ({ classes }) => {
@@ -148,6 +149,7 @@ const SystemSettings = ({ classes }) => {
       <PageContentContainer style={{ maxWidth: '1500px' }}>
         <h1>
           System Settings
+          <Button sx={{ marginLeft: '100%' }} onClick={() => window.scrollTo(0, document.body.scrollHeight)}><SouthIcon /></Button>
         </h1>
         {/* ****  **** */}
         <TaskGroupListIndex />


### PR DESCRIPTION
PermissionsAdministration.jsx can now display all persons by enabling all columns -- this shows imported persons with no permissions set.  Also can now handle null person permissions variables.

Made a new 'Only' button, that shows only the persons with that permission set.  (Permissions are boolean variables that start with 'is' or 'status').  There is also a 'Show All' button, that removes all filtering.

Made SearchBarWrapper unambiguous with ActionSearchBarWrapper and PermissionsSearchBarWrapper.

Resolves https://wevoteusa.atlassian.net/issues/WV-1117
