### PR TITLE
[Issue #WV-2028] Adds validation for questionnaire date format

### DIFF
--- a/src/js/pages/AnswerQuestions.jsx
+++ b/src/js/pages/AnswerQuestions.jsx
@@ -137,6 +137,14 @@ const AnswerQuestions = ({ classes, setShowHeaderFooter }) => {
         // Store only the integer version
         inputValuesRevised = { ...inputValuesRevised, [`questionAnswer-${questionId}`]: newValueAsInteger };
         setInputValues(inputValuesRevised);
+      } else if (question.answerType === 'DATE') {
+        // Regex for YYYY-MM-DD
+        const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+        inError = !dateRegex.test(newValue);
+        setInputValuesInError({ ...inputValuesInError, [questionId]: inError });
+        // Store the raw value if valid, otherwise store empty string
+        inputValuesRevised = { ...inputValuesRevised, [`questionAnswer-${questionId}`]: inError ? '' : newValue};
+        setInputValues(inputValuesRevised);
       } else {
         inputValuesRevised = { ...inputValuesRevised, [`questionAnswer-${questionId}`]: newValue };
         setInputValues(inputValuesRevised);
@@ -215,6 +223,9 @@ const AnswerQuestions = ({ classes, setShowHeaderFooter }) => {
       default:
       case 'STRING':
         helperText = '';
+        break;
+      case 'DATE':
+        helperText = 'Please enter the date in the format of YYYY-MM-DD (e.g., 2025-01-01).';
         break;
     }
     // console.log('helperTextIfQuestionIdInError helperText:', helperText);


### PR DESCRIPTION
### What github.com/wevote/weconnect/issues does this fix?
This PR addresses issue #WV-2028, where the start/end dates in WeConnect questionnaires that are not formatted as `YYYY-MM-DD` don't get saved.

### Changes included this pull request?
This PR adds a validation that disables the submit button when the date entered is not in the form of `YYYY-MM-DD`. It also displays an error message while the date being entered is not in the above format. The change has been tested using a test questionnaire I created locally and appears to be working as expected (see screenshot below).
<img width="457" height="146" alt="Screenshot 2025-09-09 at 11 11 33 PM" src="https://github.com/user-attachments/assets/ca99be9c-18ea-4d0c-b8e8-d5e22fa16884" />