### PR TITLE
Disable "Fast Load" if browsing the master server at teams.wevote.org

### DIFF
--- a/src/js/components/Person/AdminFunctions.jsx
+++ b/src/js/components/Person/AdminFunctions.jsx
@@ -12,7 +12,6 @@ import SlackChannelMembers from '../../pages/SystemSettings/SlackChannelMembers'
 import SlackGetPresence from '../../pages/SystemSettings/SlackGetPresence';
 import SlackListUsers from '../../pages/SystemSettings/SlackListMembers';
 import SlackSendMessage from '../../pages/SystemSettings/SlackSendMessage';
-import UploadCSV from '../../pages/SystemSettings/UploadCSV';
 
 const AdminFunctions = () => {
   renderLog('AdminFunctions');  // Set LOG_RENDER_EVENTS to log all renders
@@ -23,8 +22,8 @@ const AdminFunctions = () => {
       <div style={{ paddingTop: '2rem' }}>
         <SectionTitle>Overwrite your Local Postgres WeConnectDB with the data from the Master Database in AWS:</SectionTitle>
         <FastLoad />
-        <SectionTitle>Upload a CSV file from Google Docs to import into the local database:</SectionTitle>
-        <UploadCSV />
+        {/* <SectionTitle>Upload a CSV file from Google Docs to import into the local database:</SectionTitle> */}
+        {/* <UploadCSV /> */}
         <ButtonDividerLine />
         <SectionTitle>Google Users Creation:</SectionTitle>
         <ButtonRow>

--- a/src/js/pages/SystemSettings/FastLoad.jsx
+++ b/src/js/pages/SystemSettings/FastLoad.jsx
@@ -5,7 +5,7 @@ import Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
 import { withStyles } from '@mui/styles';
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import weConnectQueryFn, { METHOD } from '../../react-query/WeConnectQuery';
 import { ButtonPanel } from './systemSettingsCommonStyles';
 
@@ -15,14 +15,25 @@ const FastLoad = () => {
   const [open, setOpen] = useState(false);
   const [showUnanonOptions, setShowUnanonOptions] = useState(false);
   const [showUnanonButton, setShowUnanonButton] = useState(true);
+  const [buttonsDisabled, setButtonsDisabled] = useState(false);
+  const [featureDisabled, setFeatureDisabled] = useState(false);
   const [showTable, setShowTable] =  useState(false);
   const [tablesLoaded, setTablesLoaded] =  useState(0);
   const emailInputRef = useRef('');
   const passwordInputRef = useRef('');
 
-  const fastLoad = async () => {
+  useEffect(() => {
+    const { location: { hostname } } = window;
+    if (hostname.includes('wevote.org')) {
+      setFeatureDisabled(true);
+    }
+  }, []);
+
+  const doFastLoad = async () => {
     setShowUnanonButton(false);
     setShowUnanonOptions(false);
+    setButtonsDisabled(true);
+
     const $tb = $('#tableBody');
     $tb.empty();
     setShowTable(true);
@@ -93,8 +104,9 @@ const FastLoad = () => {
           size="small"
           onClick={() => handleOpen()}
           sx={{ backgroundColor: 'white', whiteSpace: 'nowrap' }}
+          disabled={featureDisabled}
         >
-          Fast Load Data From Master Server
+          {featureDisabled ? 'Fast Load can only be run from your local server' : 'Fast Load Data From Master Server'}
         </Button>
         <br />
         <Dialog
@@ -136,6 +148,7 @@ const FastLoad = () => {
               variant="outlined"
               size="small"
               onClick={handleshowUnanonOptions}
+              disabled={buttonsDisabled}
               sx={{
                 backgroundColor: 'white',
                 whiteSpace: 'nowrap',
@@ -144,7 +157,7 @@ const FastLoad = () => {
                 display: showUnanonButton ? 'flex' : 'none',
               }}
             >
-              Only click this if you are sure you need un-anonymized Data
+              Only click this if you COMPLETELY are sure you need un-anonymized Data
             </Button>
             {showUnanonOptions && (
               <>
@@ -184,7 +197,7 @@ const FastLoad = () => {
             </table>
           </DialogContent>
           <DialogActions>
-            <Button autoFocus variant="outlined" onClick={fastLoad}>
+            <Button autoFocus variant="outlined" onClick={doFastLoad}>
               Overwrite ALL local data, with data from the master server
             </Button>
           </DialogActions>

--- a/src/js/pages/SystemSettings/UploadCSV.jsx
+++ b/src/js/pages/SystemSettings/UploadCSV.jsx
@@ -12,12 +12,25 @@ import { viewerCanSeeOrDo } from '../../models/AuthModel';
 import weConnectQueryFn, { METHOD } from '../../react-query/WeConnectQuery';
 import { ButtonPanel } from './systemSettingsCommonStyles';
 
+
+/*
+This feature was used to populate local postgres databases before there was a master server, and
+it was used to initially populate the master server.  It will probably never be needed again for
+local servers, and almost certainly will not be needed to populate the master server.
+ */
 const UploadCSV = (classes) => {
   const { apiDataCache } = useConnectAppContext();
   const { viewerAccessRights } = apiDataCache;
   const [open, setOpen] = useState(false);
   const [resultsText, setResultsText] = useState([]);
+  const [featureDisabled, setFeatureDisabled] = useState(false);
 
+  useEffect(() => {
+    const { location: { hostname } } = window;
+    if (hostname.includes('wevote.org')) {
+      setFeatureDisabled(true);
+    }
+  }, []);
 
   const [isAdmin] = useState(viewerCanSeeOrDo(['canEditPermissionsAnyone'], viewerAccessRights));
 
@@ -88,8 +101,11 @@ const UploadCSV = (classes) => {
             size="small"
             onClick={() => openFilePicker()}
             sx={{ backgroundColor: 'white', whiteSpace: 'nowrap' }}
+            disabled={featureDisabled}
           >
-            Select csv file to upload
+            {featureDisabled ? 'Csv upload can only be run from your local server' : 'Select csv file to upload'}
+
+
           </Button>
           <br />
           <Dialog


### PR DESCRIPTION
I also gave the same protection to 'Upload CSV', then after thinking about it... I commented 'Upload CSV' out of the AdminFunctions since I can't think of a reason why it would ever be used again, now that we have fast load.
