### PR TITLE
[WV-2263] Move System Settings sub-pages to their own pages [TEAM REVIEW]

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,10 +22,13 @@ import Login from './js/pages/Login';
 const AnswerQuestions = React.lazy(() => import(/* webpackChunkName: 'AnswerQuestions' */ './js/pages/AnswerQuestions'));
 const FAQ = React.lazy(() => import(/* webpackChunkName: 'FAQ' */ './js/pages/FAQ'));
 // const Footer = React.lazy(() => import(/* webpackChunkName: 'Footer' */ './js/components/Navigation/Footer'));
+const GroupsOfTasksPage = React.lazy(() => import('./js/pages/SystemSettings/GroupsOfTasksPage'));
 const Header = React.lazy(() => import(/* webpackChunkName: 'Header' */ './js/components/Navigation/Header'));
 const PageNotFound = React.lazy(() => import(/* webpackChunkName: 'PageNotFound' */ './js/pages/PageNotFound'));
+const PermissionsPage = React.lazy(() => import('./js/pages/SystemSettings/PermissionsPage'));
 const QuestionnaireAnswers = React.lazy(() => import(/* webpackChunkName: 'QuestionnaireAnswers' */ './js/pages/QuestionnaireAnswers'));
 const QuestionnaireQuestionList = React.lazy(() => import(/* webpackChunkName: 'QuestionnaireQuestionList' */ './js/pages/SystemSettings/Questionnaire'));
+const QuestionnairesPage = React.lazy(() => import('./js/pages/SystemSettings/QuestionnairesPage'));
 const SystemSettings = React.lazy(() => import(/* webpackChunkName: 'SystemSettings' */ './js/pages/SystemSettings/SystemSettings'));
 const TeamHome = React.lazy(() => import(/* webpackChunkName: 'TeamHome' */ './js/pages/TeamHome'));
 const TaskGroup = React.lazy(() => import(/* webpackChunkName: 'TaskGroup' */ './js/pages/SystemSettings/TaskGroup'));
@@ -89,6 +92,9 @@ function App () {
                       <Route path="/login" element={<Login />} />
                       <Route path="/questionnaire/:questionnaireId" element={<QuestionnaireQuestionList />} />
                       <Route path="/system-settings" element={<SystemSettings />} />
+                      <Route path="/system-settings/groups-of-tasks" element={<GroupsOfTasksPage />} />
+                      <Route path="/system-settings/permissions" element={<PermissionsPage />} />
+                      <Route path="/system-settings/questionnaires" element={<QuestionnairesPage />} />
                       <Route path="/tasks" element={<Tasks />} />
                       <Route path="/task-group/:taskGroupId" element={<TaskGroup />} />
                       <Route path="/teams" element={<Teams />} />

--- a/src/js/pages/SystemSettings/GroupsOfTasksPage.jsx
+++ b/src/js/pages/SystemSettings/GroupsOfTasksPage.jsx
@@ -13,13 +13,14 @@ export default function GroupsOfTasksPage() {
         <title>Groups of Tasks - WeConnect Admin</title>
       </Helmet>
       <PageContentContainer style={{ maxWidth: '1500px' }}>
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <div style={{ display: 'flex', justifyContent: 'flex-start', alignItems: 'center', gap: '20px' }}>
           <h1>Groups of Tasks</h1>
           <Button
             variant="outlined"
+            size="small"
             onClick={() => navigate('/system-settings')}
           >
-            ← Back to System Settings
+            ← Back to Settings
           </Button>
         </div>
         <TaskGroupListIndex showTaskGroupList />

--- a/src/js/pages/SystemSettings/GroupsOfTasksPage.jsx
+++ b/src/js/pages/SystemSettings/GroupsOfTasksPage.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Helmet } from 'react-helmet-async';
+import { useNavigate } from 'react-router';
+import { Button } from '@mui/material';
+import { PageContentContainer } from '../../components/Style/pageLayoutStyles';
+import TaskGroupListIndex from './TaskGroupListIndex';
+
+export default function GroupsOfTasksPage() {
+  const navigate = useNavigate();
+  return (
+    <>
+      <Helmet>
+        <title>Groups of Tasks - WeConnect Admin</title>
+      </Helmet>
+      <PageContentContainer style={{ maxWidth: '1500px' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <h1>Groups of Tasks</h1>
+          <Button
+            variant="outlined"
+            onClick={() => navigate('/system-settings')}
+          >
+            ← Back to System Settings
+          </Button>
+        </div>
+        <TaskGroupListIndex showTaskGroupList />
+      </PageContentContainer>
+    </>
+  );
+}

--- a/src/js/pages/SystemSettings/PermissionsPage.jsx
+++ b/src/js/pages/SystemSettings/PermissionsPage.jsx
@@ -13,13 +13,14 @@ export default function PermissionsPage() {
         <title>Permissions Administration - WeConnect Admin</title>
       </Helmet>
       <PageContentContainer style={{ maxWidth: '1500px' }}>
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <div style={{ display: 'flex', justifyContent: 'flex-start', alignItems: 'center', gap: '20px' }}>
           <h1>Permissions Administration</h1>
           <Button
             variant="outlined"
+            size="small"
             onClick={() => navigate('/system-settings')}
           >
-            ← Back to System Settings
+            ← Back to Settings
           </Button>
         </div>
         <PermissionsAdministration />

--- a/src/js/pages/SystemSettings/PermissionsPage.jsx
+++ b/src/js/pages/SystemSettings/PermissionsPage.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Helmet } from 'react-helmet-async';
+import { useNavigate } from 'react-router';
+import { Button } from '@mui/material';
+import { PageContentContainer } from '../../components/Style/pageLayoutStyles';
+import PermissionsAdministration from './PermissionsAdministration';
+
+export default function PermissionsPage() {
+  const navigate = useNavigate();
+  return (
+    <>
+      <Helmet>
+        <title>Permissions Administration - WeConnect Admin</title>
+      </Helmet>
+      <PageContentContainer style={{ maxWidth: '1500px' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <h1>Permissions Administration</h1>
+          <Button
+            variant="outlined"
+            onClick={() => navigate('/system-settings')}
+          >
+            ← Back to System Settings
+          </Button>
+        </div>
+        <PermissionsAdministration />
+      </PageContentContainer>
+    </>
+  );
+}

--- a/src/js/pages/SystemSettings/Questionnaire.jsx
+++ b/src/js/pages/SystemSettings/Questionnaire.jsx
@@ -218,7 +218,7 @@ const Questionnaire = ({ classes }) => {
       </Helmet>
       <PageContentContainer>
         <QuestionnaireBreadcrumbWrapper>
-          <Link to="/system-settings" style={{ height: '40px', fontSize: 'large' }} className="u-cursor--pointer u-link-color">
+          <Link to="/system-settings/questionnaires" style={{ height: '40px', fontSize: 'large' }} className="u-cursor--pointer u-link-color">
             Questionnaires
           </Link>
           {questionnaire && questionnaire.questionnaireId && (

--- a/src/js/pages/SystemSettings/QuestionnairesPage.jsx
+++ b/src/js/pages/SystemSettings/QuestionnairesPage.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Helmet } from 'react-helmet-async';
+import { useNavigate } from 'react-router';
+import { Button } from '@mui/material';
+import { PageContentContainer } from '../../components/Style/pageLayoutStyles';
+import QuestionnaireListIndex from './QuestionnaireListIndex';
+
+export default function QuestionnairesPage() {
+  const navigate = useNavigate();
+  return (
+    <>
+      <Helmet>
+        <title>Questionnaires - WeConnect Admin</title>
+      </Helmet>
+      <PageContentContainer style={{ maxWidth: '1500px' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <h1>Questionnaires</h1>
+          <Button
+            variant="outlined"
+            onClick={() => navigate('/system-settings')}
+          >
+            ← Back to System Settings
+          </Button>
+        </div>
+        <QuestionnaireListIndex showQuestionnaireList />
+      </PageContentContainer>
+    </>
+  );
+}

--- a/src/js/pages/SystemSettings/QuestionnairesPage.jsx
+++ b/src/js/pages/SystemSettings/QuestionnairesPage.jsx
@@ -13,13 +13,14 @@ export default function QuestionnairesPage() {
         <title>Questionnaires - WeConnect Admin</title>
       </Helmet>
       <PageContentContainer style={{ maxWidth: '1500px' }}>
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <div style={{ display: 'flex', justifyContent: 'flex-start', alignItems: 'center', gap: '20px' }}>
           <h1>Questionnaires</h1>
           <Button
             variant="outlined"
+            size="small"
             onClick={() => navigate('/system-settings')}
           >
-            ← Back to System Settings
+            ← Back to Settings
           </Button>
         </div>
         <QuestionnaireListIndex showQuestionnaireList />

--- a/src/js/pages/SystemSettings/SystemSettings.jsx
+++ b/src/js/pages/SystemSettings/SystemSettings.jsx
@@ -113,42 +113,42 @@ const Content = styled(PageContentContainer)`
 
 const Label = styled('div')`
   position: absolute;
-  top: -18px;
-  left: 24px;
+  top: -24px;
+  left: 30px;
   background: #fff;
-  padding: 0 10px;
+  padding: 0 16px;
   color: #1e6fb9;
-  font-size: 22px;
-  font-weight: 600;
+  font-size: 28px;
+  font-weight: 700;
 `;
 
 const Settings = styled('div')`
   position: relative;
-  border: 2px solid #1e6fb9;
+  border: 1px solid #1e6fb9;
   border-radius: 14px;
-  padding: 45px 30px 35px;
-  max-width: 560px;
-  width: 100%;
+  padding: 60px 60px 50px;
+  max-width: 800px;
+  width: 90%;
   background: white;
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 30px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.03);
 `;
 
+
 const StyledButton = styled(Button)`
-  padding: 16px 14px;
-  border-radius: 14px;
-  min-height: 54px;
+  min-height: 60px;
+  font-size: 18px;
+  border-radius: 12px;
+  padding: 16px 20px;
   width: 100%;
-  max-width: 360px;
-  margin: 0 auto;
-  font-size: 17px;
-  font-weight: 500;
 `;
 
 const Wrapper = styled('div')`
   display: flex;
-  padding: 40px 20px;
+  justify-content: center;
+  padding: 60px 20px;
 `;
 
 export default SystemSettings;

--- a/src/js/pages/SystemSettings/SystemSettings.jsx
+++ b/src/js/pages/SystemSettings/SystemSettings.jsx
@@ -1,8 +1,8 @@
-import { KeyboardArrowDown, KeyboardArrowUp, South } from '@mui/icons-material';
+import { Workspaces as WorkspacesIcon, Quiz as QuizIcon, AdminPanelSettings as AdminPanelSettingsIcon } from '@mui/icons-material';
 import { Button } from '@mui/material';
-import { withStyles } from '@mui/styles';
 import React, { useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
+import { useNavigate } from 'react-router';
 import styled from 'styled-components';
 import { renderLog } from '../../common/utils/logging';
 import { PageContentContainer } from '../../components/Style/pageLayoutStyles';
@@ -12,20 +12,15 @@ import { viewerCanSeeOrDo } from '../../models/AuthModel';
 import capturePersonListRetrieveData from '../../models/capturePersonListRetrieveData';
 import { captureTaskDefinitionListRetrieveData, captureTaskGroupListRetrieveData, captureTaskStatusListRetrieveData } from '../../models/TaskModel';
 import { METHOD, useFetchData } from '../../react-query/WeConnectQuery';
-import PermissionsAdministration from './PermissionsAdministration';
-import QuestionnaireListIndex from './QuestionnaireListIndex';
-import TaskGroupListIndex from './TaskGroupListIndex';
-
 
 const SystemSettings = () => {
   renderLog('SystemSettings');
+  const navigate = useNavigate();
   const { apiDataCache } = useConnectAppContext();
   const { viewerAccessRights, allPeopleCache } = apiDataCache;
   const dispatch = useConnectDispatch();
 
   const [personIdsList, setPersonIdsList] = useState([]);
-  const [showQuestionnaireList, setShowQuestionnaireList] = useState(false);
-  const [showTaskGroupList, setShowTaskGroupList] = useState(false);
 
   const personListRetrieveResults = useFetchData(['person-list-retrieve'], {}, METHOD.GET);
   useEffect(() => {
@@ -71,7 +66,7 @@ const SystemSettings = () => {
   }
 
   return (
-    <div>
+    <Wrapper>
       <Helmet>
         <title>
           System Settings -
@@ -80,65 +75,80 @@ const SystemSettings = () => {
         </title>
         <link rel="canonical" href={`${webAppConfig.WECONNECT_URL_FOR_SEO}/system-settings`} />
       </Helmet>
-      <PageContentContainer style={{ maxWidth: '1500px' }}>
-        <h1>
-          System Settings
-        </h1>
-        <Button sx={{ marginLeft: '100%' }} onClick={() => window.scrollTo(0, document.body.scrollHeight)}><South /></Button>
-        {/* ****  **** */}
-        <SettingsSubtitle>
-          <span onClick={() => setShowTaskGroupList(!showTaskGroupList)}>
-            {showTaskGroupList ? (
-              <KeyboardArrowUpStyled />
-            ) : (
-              <KeyboardArrowDownStyled />
-            )}
-          </span>
-          Groups of Tasks
-        </SettingsSubtitle>
-        <TaskGroupListIndex showTaskGroupList={showTaskGroupList} />
-        {/* ****  **** */}
-        <SettingsSubtitle>
-          <span onClick={() => setShowQuestionnaireList(!showQuestionnaireList)}>
-            {showQuestionnaireList ? (
-              <KeyboardArrowUpStyled />
-            ) : (
-              <KeyboardArrowDownStyled />
-            )}
-          </span>
-          Questionnaires
-        </SettingsSubtitle>
-        <QuestionnaireListIndex showQuestionnaireList={showQuestionnaireList} />
-        {/* ****  **** */}
-        <SettingsSubtitle>Permissions Administration</SettingsSubtitle>
-        <PermissionsAdministration />
-      </PageContentContainer>
-    </div>
+      <Content>
+        <Settings>
+          <Label>System Settings</Label>
+          <StyledButton
+            variant="contained"
+            startIcon={<WorkspacesIcon />}
+            onClick={() => navigate('/system-settings/groups-of-tasks')}
+          >
+            Groups of Tasks
+          </StyledButton>
+          <StyledButton
+            variant="contained"
+            startIcon={<QuizIcon />}
+            onClick={() => navigate('/system-settings/questionnaires')}
+          >
+            Questionnaires
+          </StyledButton>
+          <StyledButton
+            variant="contained"
+            startIcon={<AdminPanelSettingsIcon />}
+            onClick={() => navigate('/system-settings/permissions')}
+          >
+            Permissions Administration
+          </StyledButton>
+        </Settings>
+      </Content>
+    </Wrapper>
   );
 };
 SystemSettings.propTypes = {
 };
 
-const styles = (theme) => ({
-  ballotButtonIconRoot: {
-    marginRight: 8,
-  },
-  addQuestionnaireButtonRoot: {
-    width: 185,
-    [theme.breakpoints.down('md')]: {
-      width: '100%',
-    },
-  },
-});
-
-const KeyboardArrowDownStyled = styled(KeyboardArrowDown)`
+const Content = styled(PageContentContainer)`
+  text-align: center;
 `;
 
-const KeyboardArrowUpStyled = styled(KeyboardArrowUp)`
+const Label = styled('div')`
+  position: absolute;
+  top: -18px;
+  left: 24px;
+  background: #fff;
+  padding: 0 10px;
+  color: #1e6fb9;
+  font-size: 22px;
+  font-weight: 600;
 `;
 
-const SettingsSubtitle = styled('h2')`
-  margin-bottom: 0;
+const Settings = styled('div')`
+  position: relative;
+  border: 2px solid #1e6fb9;
+  border-radius: 14px;
+  padding: 45px 30px 35px;
+  max-width: 560px;
+  width: 100%;
+  background: white;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
 `;
 
-export default withStyles(styles)(SystemSettings);
+const StyledButton = styled(Button)`
+  padding: 16px 14px;
+  border-radius: 14px;
+  min-height: 54px;
+  width: 100%;
+  max-width: 360px;
+  margin: 0 auto;
+  font-size: 17px;
+  font-weight: 500;
+`;
+
+const Wrapper = styled('div')`
+  display: flex;
+  padding: 40px 20px;
+`;
+
+export default SystemSettings;

--- a/src/js/pages/SystemSettings/TaskGroup.jsx
+++ b/src/js/pages/SystemSettings/TaskGroup.jsx
@@ -126,7 +126,7 @@ const TaskGroup = ({ classes }) => {
       </Helmet>
       <PageContentContainer>
         <TaskGroupBreadcrumbWrapper>
-          <Link to="/system-settings">Task Groups</Link>
+          <Link to="/system-settings/groups-of-tasks">Task Groups</Link>
           {' '}
           &gt;
           {' '}


### PR DESCRIPTION
New system settings page: 
<img width="1458" height="910" alt="image" src="https://github.com/user-attachments/assets/eb78a3e7-4c68-4c4c-ae29-ff97904c0ecf" />

**Sub-pages:**

Groups of Tasks:
<img width="2286" height="565" alt="image" src="https://github.com/user-attachments/assets/77e7ee01-572c-4aa5-bb36-a02410c3202f" />
Questionnaires:
<img width="2300" height="452" alt="image" src="https://github.com/user-attachments/assets/c8648448-e7b3-400f-8f82-115420c51ec5" />
Permissions:
<img width="2378" height="540" alt="image" src="https://github.com/user-attachments/assets/18229f65-6265-498c-a791-2162dbd60804" />
