### PR TITLE
[WV-2260] WeConnect: Fix button at bottom of drawer so it is always visible[Team Review]

### DIFF
--- a/src/js/components/Person/AddPersonForm.jsx
+++ b/src/js/components/Person/AddPersonForm.jsx
@@ -205,15 +205,17 @@ const AddPersonForm = ({ classes }) => {  //  classes, teamId
           )}
           label="Has signed offer letter"
         />
-        <Button
-          classes={{ root: classes.saveNewPersonButton }}
-          color="primary"
-          disabled={!saveButtonActive}
-          variant="contained"
-          onClick={saveNewPerson}
-        >
-          Save New Person
-        </Button>
+        <ButtonWrapper>
+          <Button
+            classes={{ root: classes.saveNewPersonButton }}
+            color="primary"
+            disabled={!saveButtonActive}
+            variant="contained"
+            onClick={saveNewPerson}
+          >
+            Save New Person
+          </Button>
+        </ButtonWrapper>
       </FormControl>
     </AddPersonFormWrapper>
   );
@@ -240,6 +242,16 @@ const styles = (theme) => ({
 });
 
 const AddPersonFormWrapper = styled('div')`
+`;
+
+const ButtonWrapper = styled('div')`
+  background-color: #fff;
+  bottom: 0;
+  padding: 8px 0;
+  position: sticky;
+  width: 100%;
+  margin-bottom: 24px;
+  z-index: 1;
 `;
 
 const CheckboxLabel = styled(FormControlLabel)`

--- a/src/js/components/Task/EditTaskGroupForm.jsx
+++ b/src/js/components/Task/EditTaskGroupForm.jsx
@@ -470,15 +470,17 @@ const EditTaskGroupForm = ({ classes }) => {
             ))}
           </Select>
         </FormControl>
-        <Button
-          classes={{ root: classes.saveTaskGroupButton }}
-          color="primary"
-          disabled={!saveButtonActive}
-          variant="contained"
-          onClick={saveTaskGroupForm}
-        >
-          Save Task Grouping
-        </Button>
+        <ButtonWrapper>
+          <Button
+            classes={{ root: classes.saveTaskGroupButton }}
+            color="primary"
+            disabled={!saveButtonActive}
+            variant="contained"
+            onClick={saveTaskGroupForm}
+          >
+            Save Task Grouping
+          </Button>
+        </ButtonWrapper>
       </FormControl>
     </EditTaskGroupFormWrapper>
   );
@@ -521,6 +523,16 @@ const styles = (theme) => ({
 const AssignTasksToPersonHeader = styled('div')`
   margin-top: 24px;
   font-weight: bold;
+`;
+
+const ButtonWrapper = styled('div')`
+  background-color: #fff;
+  bottom: 0;
+  padding: 8px 0;
+  position: sticky;
+  width: 100%;
+  margin-bottom: 24px;
+  z-index: 1;
 `;
 
 const CheckboxLabel = styled(FormControlLabel)`


### PR DESCRIPTION
### What github.com/wevote/weconnect/issues does this fix?
Fixes [WV-2260] WeConnect: Fix button at bottom of drawer so it is always visible
Wrapped Save New Person and Submit buttons in a sticky-position container
### Changes included this pull request?
src/js/components/Person/AddPersonForm.jsx
src/js/components/Task/EditTaskGroupForm.jsx

[WV-2260]: https://wevoteusa.atlassian.net/browse/WV-2260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ