### PR TITLE
"Add to Team" fixes and task-status-list-retrieve changed to POST fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,3 +307,15 @@ selecting 'Inspect' at the bottom of the right-click menu.
 
 When you navigate in Chrome to `http://localhost:4000/` you will see the client login page.
 
+Sometime in 2025, Chrome stopped loading locally defined websites, even if they have valid public SSL certificates, 
+so if you use chrome, you will have to use http.
+
+
+### View the app in the Safari browser
+
+When you navigate in Safari to `https://wevotedeveloper.com:4000/` you will see the client login page.
+
+Safari has a devtools like feature called "WebInspector" that is highly equivalent to devtools in Chrome.
+
+If you are running Chrome pointed to localhost, and you find some feature that doesn't work, give Safari a try.
+

--- a/README.md
+++ b/README.md
@@ -308,7 +308,8 @@ selecting 'Inspect' at the bottom of the right-click menu.
 When you navigate in Chrome to `http://localhost:4000/` you will see the client login page.
 
 Sometime in 2025, Chrome stopped loading locally defined websites, even if they have valid public SSL certificates, 
-so if you use chrome, you will have to use http.
+so if you use chrome, you will have to use http.  This is not a problem on our publicly deployed instance at 
+`https://team.wevote.org`, Chrome works perfectly well at our public site.
 
 
 ### View the app in the Safari browser

--- a/src/js/components/Navigation/HeaderBar.jsx
+++ b/src/js/components/Navigation/HeaderBar.jsx
@@ -161,7 +161,7 @@ const HeaderBar = ({ hideTabs }) => {
 
   const handleTabChange = (event, newValue) => {
     // setTabsValue(newValue);
-    console.log('----------', newValue);
+    console.log('handleTabChange ----------', newValue);
     if (newValue) {
       switch (newValue) {
         case HEADER_TAB_DASHBOARD:

--- a/src/js/components/Navigation/HeaderBar.jsx
+++ b/src/js/components/Navigation/HeaderBar.jsx
@@ -97,7 +97,7 @@ const HeaderBar = ({ hideTabs }) => {
     return Object.values(allPeopleCache).map((p) => p.personId);
   }, [allPeopleCache]);
 
-  const taskStatusListRetrieveResults = useFetchData(['task-status-list-retrieve'], { personIdList: personIdsList }, METHOD.GET, personIdsList.length > 0 && goodAllPeopleCache,
+  const taskStatusListRetrieveResults = useFetchData(['task-status-list-retrieve'], { personIdList: personIdsList }, METHOD.POST, personIdsList.length > 0 && goodAllPeopleCache,
     { refetchInterval: 30000, refetchIntervalInBackground: false });
   useEffect(() => {
     if (taskStatusListRetrieveResults) {

--- a/src/js/components/Person/AddPersonDrawerMainContent.jsx
+++ b/src/js/components/Person/AddPersonDrawerMainContent.jsx
@@ -1,22 +1,16 @@
 import { TextField } from '@mui/material';
 import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
+import CrossIcon from '../../../img/global/svg-icons/cross.svg';
 import arrayContains from '../../common/utils/arrayContains';
 import { renderLog } from '../../common/utils/logging';
 import { useConnectAppContext } from '../../contexts/ConnectAppContext';
 import { getTeamMemberPersonListByTeamId } from '../../models/TeamModel';
-import makeRequestParams from '../../react-query/makeRequestParams';
 import { useAddPersonToTeamMutation } from '../../react-query/mutations';
-import {
-  alphabetizePeoplesObject,
-  filterNamesWithDEPRICATEKey,
-  orderListByFurthestFutureStartDate,
-  sortByNoTeamFirst,
-} from '../../utils/utilities';
+import { alphabetizePeoplesObject, filterNamesWithDEPRICATEKey, orderListByFurthestFutureStartDate, sortByNoTeamFirst } from '../../utils/utilities';
 import { SpanWithLinkStyle } from '../Style/linkStyles';
 import { MatchingPerson, SearchBarWrapper } from '../Style/sharedStyles';
 import AddPersonForm from './AddPersonForm';
-import CrossIcon from '../../../img/global/svg-icons/cross.svg';
 
 const LIMIT_NUMBER_SHOWN = 20;
 
@@ -80,7 +74,7 @@ const AddPersonDrawerMainContent = () => {
     addToTeamListTemp = sortByNoTeamFirst(addToTeamListTemp, allPeopleTeamIdLists);
     addToTeamListTemp = orderListByFurthestFutureStartDate(addToTeamListTemp);
     addToTeamListTemp = filterNamesWithDEPRICATEKey(addToTeamListTemp);
-    addToTeamListTemp = addToTeamListTemp.filter((person) => (person.statusActive !== false) && (person.statusResigned !== true)).slice(0, LIMIT_NUMBER_SHOWN);
+    addToTeamListTemp = addToTeamListTemp.filter((person) => (person.statusActive === true) && (person.statusResigned !== true) && (person.statusOfferWillNotBeMade !== true)).slice(0, LIMIT_NUMBER_SHOWN);
     addToTeamListTemp = alphabetizePeoplesObject(addToTeamListTemp, true);
     setAddToTeamList(addToTeamListTemp);
   }, [searchResultsList, remainingPeopleToAdd]);
@@ -126,17 +120,16 @@ const AddPersonDrawerMainContent = () => {
     const personId = incomingPerson ? incomingPerson.personId : -1;
     const teamId = team ? team.teamId : -1;
     const teamName = team ? team.teamName : '';
-    const plainParams = {
+    const params = {
       personId,
       teamId,
-    };
-    addPersonToTeam(makeRequestParams(plainParams, {
       teamMemberFirstName: incomingPerson.firstName,
       teamMemberLastName: incomingPerson.lastName,
       teamName,
-    }));
-    // Remove this person from the All People less Adds list (since they were added to the team)
+    };
+    addPersonToTeam(params);
 
+    // Remove this person from the All People less Adds list (since they were added to the team)
     const updatedRemainingPeopleToAdd = remainingPeopleToAdd.filter((person) => person.personId !== incomingPerson.personId);
     setRemainingPeopleToAdd(updatedRemainingPeopleToAdd);
     if (searchResultsList && searchResultsList.length >= 0) {

--- a/src/js/components/Person/AddPersonForm.jsx
+++ b/src/js/components/Person/AddPersonForm.jsx
@@ -4,11 +4,11 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { renderLog } from '../../common/utils/logging';
-import { useConnectAppContext } from '../../contexts/ConnectAppContext';
-import makeRequestParams from '../../react-query/makeRequestParams';
-import { usePersonSaveMutation } from '../../react-query/mutations';
-import { viewerCanSeeOrDo } from '../../models/AuthModel';
 import webAppConfig from '../../config';
+import { useConnectAppContext } from '../../contexts/ConnectAppContext';
+import { viewerCanSeeOrDo } from '../../models/AuthModel';
+import { makeRequestParamsDictionary } from '../../react-query/makeRequestParams';
+import { usePersonSaveMutation } from '../../react-query/mutations';
 import { isValidUSStateCode } from '../../utils/stateUtils';
 
 const AddPersonForm = ({ classes }) => {  //  classes, teamId
@@ -70,7 +70,7 @@ const AddPersonForm = ({ classes }) => {  //  classes, teamId
       teamId,
       teamName,
     };
-    personSave(makeRequestParams(plainParams, data));
+    personSave(makeRequestParamsDictionary(plainParams, data));
     setAppContextValue('addPersonDrawerOpen', false);
     setAppContextValue('addPersonDrawerLabel', '');
     setAppContextValue('addPersonDrawerTeam', undefined);

--- a/src/js/components/Person/EditPersonForm.jsx
+++ b/src/js/components/Person/EditPersonForm.jsx
@@ -16,7 +16,7 @@ import { renderLog } from '../../common/utils/logging';
 import webAppConfig from '../../config';
 import { useConnectAppContext } from '../../contexts/ConnectAppContext';
 import { viewerCanSeeOrDo } from '../../models/AuthModel';
-import makeRequestParams from '../../react-query/makeRequestParams';
+import { makeRequestParamsDictionary } from '../../react-query/makeRequestParams';
 import { usePersonSaveMutation } from '../../react-query/mutations';
 import weConnectQueryFn, { METHOD } from '../../react-query/WeConnectQuery';
 import { ActionOption, ActionOptionContainerLeft8, ActionOptionContainerOverflow, ActionOptionList } from '../Style/actionOptionStyles';
@@ -157,14 +157,11 @@ const EditPersonForm = ({ classes }) => {
     const plainParams = {
       personId: activePerson.id,
     };
-
-    personSave(makeRequestParams(plainParams, data));
+    personSave(makeRequestParamsDictionary(plainParams, data));
     setSaveButtonActive(false);
-    // setTimeout(() => {
     setAppContextValue('headerProfileDrawerOpen', false);
     setAppContextValue('profileDrawerPerson', undefined);
     setAppContextValue('profileDrawerPersonId', -1);
-    // }, 500);
   };
 
   const setEmailOfficialFromChild = (emailOfficial) => {

--- a/src/js/components/Questionnaire/EditQuestionForm.jsx
+++ b/src/js/components/Questionnaire/EditQuestionForm.jsx
@@ -112,6 +112,7 @@ const EditQuestionForm = ({ classes }) => {
       statusActive: (statusActiveInputRef.current.checked),
     };
     const requestParams = makeRequestParamsDictionary(plainParams, params);
+
     mutateQuestionSave(requestParams);
     // console.log('saveQuestionnaire requestParams:', requestParams);
     setSaveButtonActive(false);

--- a/src/js/components/Questionnaire/EditQuestionForm.jsx
+++ b/src/js/components/Questionnaire/EditQuestionForm.jsx
@@ -8,7 +8,7 @@ import styled from 'styled-components';
 import DesignTokenColors from '../../common/components/Style/DesignTokenColors';
 import { renderLog } from '../../common/utils/logging';
 import { useConnectAppContext } from '../../contexts/ConnectAppContext';
-import makeRequestParams from '../../react-query/makeRequestParams';
+import { makeRequestParamsDictionary } from '../../react-query/makeRequestParams';
 import { useQuestionSaveMutation } from '../../react-query/mutations';
 import { SpanWithLinkStyle } from '../Style/linkStyles';
 
@@ -111,7 +111,7 @@ const EditQuestionForm = ({ classes }) => {
       requireAnswer: (requireAnswerInputRef.current.checked),
       statusActive: (statusActiveInputRef.current.checked),
     };
-    const requestParams = makeRequestParams(plainParams, params);
+    const requestParams = makeRequestParamsDictionary(plainParams, params);
     mutateQuestionSave(requestParams);
     // console.log('saveQuestionnaire requestParams:', requestParams);
     setSaveButtonActive(false);

--- a/src/js/components/Questionnaire/EditQuestionForm.jsx
+++ b/src/js/components/Questionnaire/EditQuestionForm.jsx
@@ -112,7 +112,6 @@ const EditQuestionForm = ({ classes }) => {
       statusActive: (statusActiveInputRef.current.checked),
     };
     const requestParams = makeRequestParamsDictionary(plainParams, params);
-
     mutateQuestionSave(requestParams);
     // console.log('saveQuestionnaire requestParams:', requestParams);
     setSaveButtonActive(false);

--- a/src/js/components/Questionnaire/EditQuestionnaireForm.jsx
+++ b/src/js/components/Questionnaire/EditQuestionnaireForm.jsx
@@ -1,4 +1,4 @@
-import { Button, Checkbox, FormControl, FormControlLabel, TextField, } from '@mui/material';
+import { Button, Checkbox, FormControl, FormControlLabel, TextField } from '@mui/material';
 import { withStyles } from '@mui/styles';
 import PropTypes from 'prop-types';
 import React, { useEffect, useRef, useState } from 'react';

--- a/src/js/components/Questionnaire/EditQuestionnaireForm.jsx
+++ b/src/js/components/Questionnaire/EditQuestionnaireForm.jsx
@@ -1,17 +1,11 @@
-import {
-  Button,
-  Checkbox,
-  FormControl,
-  FormControlLabel,
-  TextField,
-} from '@mui/material';
+import { Button, Checkbox, FormControl, FormControlLabel, TextField, } from '@mui/material';
 import { withStyles } from '@mui/styles';
 import PropTypes from 'prop-types';
 import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { renderLog } from '../../common/utils/logging';
 import { useConnectAppContext } from '../../contexts/ConnectAppContext';
-import makeRequestParams from '../../react-query/makeRequestParams';
+import { makeRequestParamsDictionary } from '../../react-query/makeRequestParams';
 import { useQuestionnaireSaveMutation } from '../../react-query/mutations';
 
 
@@ -59,7 +53,7 @@ const EditQuestionnaireForm = ({ classes }) => {
     const plainParams = {
       questionnaireId: questionnaire ? questionnaire.id : '-1',
     };
-    mutateQuestionnaireSave(makeRequestParams(plainParams, params));
+    mutateQuestionnaireSave(makeRequestParamsDictionary(plainParams, params));
     setSaveButtonActive(false);
     setAppContextValue('editQuestionnaireDrawerOpen', false);
     setAppContextValue('selectedQuestionnaire', undefined);

--- a/src/js/components/Task/EditTaskDefinitionForm.jsx
+++ b/src/js/components/Task/EditTaskDefinitionForm.jsx
@@ -1,4 +1,4 @@
-import { Button, Checkbox, FormControl, FormControlLabel, TextField, } from '@mui/material';
+import { Button, Checkbox, FormControl, FormControlLabel, TextField } from '@mui/material';
 import { withStyles } from '@mui/styles';
 import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useRef, useState } from 'react';

--- a/src/js/components/Task/EditTaskDefinitionForm.jsx
+++ b/src/js/components/Task/EditTaskDefinitionForm.jsx
@@ -1,16 +1,11 @@
-import {
-  Button, Checkbox,
-  FormControl,
-  FormControlLabel,
-  TextField,
-} from '@mui/material';
+import { Button, Checkbox, FormControl, FormControlLabel, TextField, } from '@mui/material';
 import { withStyles } from '@mui/styles';
 import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { renderLog } from '../../common/utils/logging';
 import { useConnectAppContext } from '../../contexts/ConnectAppContext';
-import makeRequestParams from '../../react-query/makeRequestParams';
+import { makeRequestParamsDictionary } from '../../react-query/makeRequestParams';
 import { useTaskDefinitionSaveMutation } from '../../react-query/mutations';
 
 const EditTaskDefinitionForm = ({ classes }) => {
@@ -109,7 +104,7 @@ const EditTaskDefinitionForm = ({ classes }) => {
 
   const saveTaskDefinition = () => {
     // console.log('Saving task definition statusOfferDecisionNeededSetFalse:', statusOfferDecisionNeededSetFalse);
-    const requestParams = makeRequestParams({
+    const requestParams = makeRequestParamsDictionary({
       taskDefinitionId: taskDefinition ? taskDefinition.id : '-1',
       taskGroupId: taskGroup.taskGroupId,
     }, {

--- a/src/js/components/Task/EditTaskGroupForm.jsx
+++ b/src/js/components/Task/EditTaskGroupForm.jsx
@@ -168,6 +168,7 @@ const EditTaskGroupForm = ({ classes }) => {
     taskGroupTeamLinkSave(requestParams);
   };
 
+
   const saveTaskGroupForm = () => {
     saveTaskGroup();
     saveTaskGroupTeamLink();

--- a/src/js/components/Task/EditTaskGroupForm.jsx
+++ b/src/js/components/Task/EditTaskGroupForm.jsx
@@ -12,7 +12,7 @@ import styled from 'styled-components';
 import convertToInteger from '../../common/utils/convertToInteger';
 import { renderLog } from '../../common/utils/logging';
 import { useConnectAppContext, useConnectDispatch } from '../../contexts/ConnectAppContext';
-import makeRequestParams from '../../react-query/makeRequestParams';
+import makeRequestParams, { makeRequestParamsDictionary } from '../../react-query/makeRequestParams';
 import { useTaskGroupTeamLinkDeleteMutation, useTaskGroupTeamLinkSaveMutation, useTaskGroupSaveMutation } from '../../react-query/mutations';
 import { METHOD, useFetchData } from '../../react-query/WeConnectQuery';
 import { SpanWithLinkStyle } from '../Style/linkStyles';
@@ -139,7 +139,7 @@ const EditTaskGroupForm = ({ classes }) => {
   };
 
   const saveTaskGroup = () => {
-    const requestParams = makeRequestParams({
+    const requestParams = makeRequestParamsDictionary({
       taskGroupId: taskGroup ? taskGroup.id : '-1',
     }, {
       assignIfEmailCreated,
@@ -161,7 +161,7 @@ const EditTaskGroupForm = ({ classes }) => {
   };
 
   const saveTaskGroupTeamLink = () => {
-    const requestParams = makeRequestParams({
+    const requestParams = makeRequestParamsDictionary({
       taskGroupId: taskGroup ? taskGroup.id : '-1',
       teamId: taskGroupTeamId,
     }, {});

--- a/src/js/components/Task/EditTaskGroupForm.jsx
+++ b/src/js/components/Task/EditTaskGroupForm.jsx
@@ -168,7 +168,6 @@ const EditTaskGroupForm = ({ classes }) => {
     taskGroupTeamLinkSave(requestParams);
   };
 
-
   const saveTaskGroupForm = () => {
     saveTaskGroup();
     saveTaskGroupTeamLink();

--- a/src/js/components/Task/TaskListForPersonManager.jsx
+++ b/src/js/components/Task/TaskListForPersonManager.jsx
@@ -66,6 +66,7 @@ const TaskListForPersonManager = ({ personId }) => {
         savePromises.push(saveTask(requestParams));
       }
     });
+
     try {
       await Promise.all(savePromises);
       console.log('All tasks marked as done successfully');

--- a/src/js/components/Task/TaskListForPersonManager.jsx
+++ b/src/js/components/Task/TaskListForPersonManager.jsx
@@ -2,17 +2,17 @@ import { Lock } from '@mui/icons-material';
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
+import DesignTokenColors from '../../common/components/Style/DesignTokenColors';
 import { renderLog } from '../../common/utils/logging';
-import TaskListForPerson from './TaskListForPerson';
+import { useConnectAppContext, useConnectDispatch } from '../../contexts/ConnectAppContext';
 import { viewerCanSeeOrDo } from '../../models/AuthModel';
 import { useGetPersonById } from '../../models/PersonModel';
-import { useConnectAppContext, useConnectDispatch } from '../../contexts/ConnectAppContext';
-import { METHOD, useFetchData } from '../../react-query/WeConnectQuery';
 import { captureTaskDefinitionListRetrieveData } from '../../models/TaskModel';
-import { SpanWithLinkStyle } from '../Style/linkStyles';
-import makeRequestParams from '../../react-query/makeRequestParams';
+import { makeRequestParamsDictionary } from '../../react-query/makeRequestParams';
 import { useSaveTaskMutation } from '../../react-query/mutations';
-import DesignTokenColors from '../../common/components/Style/DesignTokenColors';
+import { METHOD, useFetchData } from '../../react-query/WeConnectQuery';
+import { SpanWithLinkStyle } from '../Style/linkStyles';
+import TaskListForPerson from './TaskListForPerson';
 
 
 const TaskListForPersonManager = ({ personId }) => {
@@ -56,7 +56,7 @@ const TaskListForPersonManager = ({ personId }) => {
 
     taskListForThisPerson.forEach((task) => {
       if (!task.statusDone) {  // Only mark undone tasks as done
-        const requestParams = makeRequestParams({
+        const requestParams = makeRequestParamsDictionary({
           personId,
           taskDefinitionId: task.taskDefinitionId,
         }, {

--- a/src/js/components/Task/TaskSummaryRow.jsx
+++ b/src/js/components/Task/TaskSummaryRow.jsx
@@ -58,7 +58,6 @@ const TaskSummaryRow = ({ hideIfCompleted, personId, showMarkCompletedLinkOnTitl
     });
     saveTask(requestParams);
   };
-
   if (!task) {
     return null;
   }

--- a/src/js/components/Task/TaskSummaryRow.jsx
+++ b/src/js/components/Task/TaskSummaryRow.jsx
@@ -58,6 +58,7 @@ const TaskSummaryRow = ({ hideIfCompleted, personId, showMarkCompletedLinkOnTitl
     });
     saveTask(requestParams);
   };
+
   if (!task) {
     return null;
   }

--- a/src/js/components/Task/TaskSummaryRow.jsx
+++ b/src/js/components/Task/TaskSummaryRow.jsx
@@ -5,16 +5,16 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import DesignTokenColors from '../../common/components/Style/DesignTokenColors';
-import { SpanWithLinkStyle } from '../Style/linkStyles';
 import { formatDateToMonthDay, formatDateToMonthDayYear } from '../../common/utils/dateFormat';
 import { renderLog } from '../../common/utils/logging';
-import makeRequestParams from '../../react-query/makeRequestParams';
+import { useConnectAppContext } from '../../contexts/ConnectAppContext';
+import { viewerCanSeeOrDo } from '../../models/AuthModel';
+import { useGetFirstNamePreferred, useGetFullNamePreferred } from '../../models/PersonModel';
+import { makeRequestParamsDictionary } from '../../react-query/makeRequestParams';
 import { useSaveTaskMutation } from '../../react-query/mutations';
 import DisplayWhatToDoTextAsActiveJSX from '../../utils/DisplayWhatToDoTextAsActiveJSX';
-import { useConnectAppContext } from '../../contexts/ConnectAppContext';
-import { useGetFirstNamePreferred, useGetFullNamePreferred } from '../../models/PersonModel';
-import { viewerCanSeeOrDo } from '../../models/AuthModel';
 import GoogleDriveShareManager from '../Person/GoogleDriveShareManager';
+import { SpanWithLinkStyle } from '../Style/linkStyles';
 
 
 const TaskSummaryRow = ({ hideIfCompleted, personId, showMarkCompletedLinkOnTitleLine, showPersonName, taskDefinition, task }) => {
@@ -49,7 +49,7 @@ const TaskSummaryRow = ({ hideIfCompleted, personId, showMarkCompletedLinkOnTitl
   }, [authenticatedPerson, getAppContextValue]);
 
   const updateTaskFieldInstant = (isDone) => {
-    const requestParams = makeRequestParams({
+    const requestParams = makeRequestParamsDictionary({
       personId,
       taskDefinitionId: task.taskDefinitionId,
     }, {

--- a/src/js/components/Task/TasksDataRetrieve.jsx
+++ b/src/js/components/Task/TasksDataRetrieve.jsx
@@ -19,7 +19,7 @@ const TasksDataRetrieve = () => {
   const { allPeopleCache } = apiDataCache;
   const dispatch = useConnectDispatch();
 
-  const [personIdsList, setPersonIdsList] = useState([]);
+  const [personIdList, setPersonIdList] = useState([]);
 
   const personListRetrieveResults = useFetchData(['person-list-retrieve'], {}, METHOD.GET);
   useEffect(() => {
@@ -49,12 +49,16 @@ const TasksDataRetrieve = () => {
     }
   }, [apiDataCache, dispatch, taskGroupListRetrieveResults]);
 
-  const taskStatusListRetrieveResults = useFetchData(['task-status-list-retrieve'], { personIdList: personIdsList }, METHOD.GET);
+  // curl -H 'Content-Type: application/json' -d '{\"personIdsList\":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,162,163,164,165,166,167,168,169,170,171,172,173,174,175,176,177,178,179,180,181,182,183,184,185,186,188,189,190,191,192,193,194,195,197,198,199,200,201,202,203,204,205,206,207,208,209,210,211,212,213,215,216,217,218,219,220,221,222,223,224,225,226,227,228,229,230,231,232,233,234,235,236,237,238,239,240,241,242,243,244,245,246,247,248,249,250,251,252,253,254,255,256,257,258,259,260,261,262,263,264,265,266,267,268,269,270,271,272,273,274,275,276,277,278,279,280,281,282,283,284,285,286,287,288,289,290,291,292,293,294,295,296,297,298,299,300,301,302,303,304,305,306,307,308,309,310,311,312,313,314,315,316,317,318,319,320,321,322,323,324,325,326,327,328,329,330,331,332,333,334,335,336,337,338,339,340,341,342,343,344,345,346,347,348,349,350,351,352,353,354,355,356,357,358,359,360,361,362,363,364,365,366,367,368,369,370,371,372,373,374,375,376,377,378,379,380,381,382]}' https://wevotedeveloper.com:4500/apis/v1/task-status-list-retrieve/
+
+  const taskStatusListRetrieveResults = useFetchData(['task-status-list-retrieve'], { personIdList }, METHOD.POST);
   useEffect(() => {
     if (taskStatusListRetrieveResults) {
       captureTaskStatusListRetrieveData(taskStatusListRetrieveResults, apiDataCache, dispatch);
     }
-  }, [personIdsList, taskStatusListRetrieveResults]);
+  }, [taskStatusListRetrieveResults]);
+
+  // console.log('~~~~~ taskStatusListRetrieveResults', taskStatusListRetrieveResults);
 
   const teamListRetrieveResults = useFetchData(['team-list-retrieve'], {}, METHOD.GET);
   useEffect(() => {
@@ -67,7 +71,7 @@ const TasksDataRetrieve = () => {
     // console.log('TasksDataRetrieve useEffect allPeopleCache:', allPeopleCache);
     if (allPeopleCache) {
       const allCachedPeopleList = Object.values(allPeopleCache);
-      setPersonIdsList(allCachedPeopleList.map((person) => person.personId));
+      setPersonIdList(allCachedPeopleList.map((person) => person.personId));
     }
   }, [allPeopleCache]);
 

--- a/src/js/components/Team/TeamMemberList.jsx
+++ b/src/js/components/Team/TeamMemberList.jsx
@@ -18,6 +18,7 @@ const TeamMemberList = ({ expandAllTeamMembers, hideInactive, searchText, teamId
   const dispatch = useConnectDispatch();
 
   const [teamMemberListApiDataCache, setTeamMemberListApiDataCache] = useState([]);
+  // eslint-disable-next-line no-unused-vars
   const [teamMemberListReactQuery, setTeamMemberListReactQuery] = useState(team.teamMemberList || []);
 
   const personListRetrieveResults = useFetchData(['person-list-retrieve'], {}, METHOD.GET);
@@ -46,31 +47,7 @@ const TeamMemberList = ({ expandAllTeamMembers, hideInactive, searchText, teamId
     setTeamMemberListApiDataCache(updatedTeamMemberList);
   }, [apiDataCache, teamId]);
 
-  // const oneTeam = teamList.find((tm) => tm.teamId === parseInt(teamId));
-
-  // DO NOT REMOVE: diffs the ReactQuery cache results with the ApiDataCache
-  let isPerfectMatch = true;
-  if (teamMemberListReactQuery && teamMemberListApiDataCache && teamMemberListReactQuery.length > 0 && teamMemberListApiDataCache.length > 0) {
-    for (let i = 0; i < teamMemberListReactQuery.length; i++) {
-      Object.keys(teamMemberListReactQuery[i]).forEach((key) => {
-        if (key !== 'id' && !key.startsWith('date')) {
-          const valReactQueryCache = teamMemberListReactQuery && teamMemberListReactQuery[i] && teamMemberListReactQuery[i][key];
-          const valApiCacheQuery = teamMemberListApiDataCache && teamMemberListApiDataCache[i] && teamMemberListApiDataCache[i][key];
-          if (valApiCacheQuery !== valReactQueryCache) {
-            // console.log(`ERROR: teamMemberList authoritative ReactQuery cache for key: ${key} value: '${valReactQueryCache}' does not match processed cache value: '${valApiCacheQuery}'`);
-            isPerfectMatch = false;
-          }
-        }
-      });
-    }
-    if (isPerfectMatch) {
-      // console.log('=== PERFECT MATCH');
-    }
-  } else {
-    // console.log(`=== CANNOT COMPARE: teamMemberListReactQuery.length: ${teamMemberListReactQuery.length}, teamMemberListApiDataCache.length: ${teamMemberListApiDataCache.length}`);
-  }
-  // console.log('====== Cached by ReactQuery teamMemberList: ', teamMemberListReactQuery);
-  // console.log('====== Cached by apiDataCache teamMemberList: ', teamMemberListApiDataCache);
+  // console.log(`====== Cached by apiDataCache teamMemberList (${teamId}): ${JSON.stringify(teamMemberListApiDataCache)}`);
 
   return (
     <TeamMembersWrapper>

--- a/src/js/constants/DepartmentConstants.js
+++ b/src/js/constants/DepartmentConstants.js
@@ -8,7 +8,6 @@ export const DEPARTMENTS = {
   OTHER: 'Other team',
 };
 
-
 export const DEPARTMENT_LIST = [
   DEPARTMENTS.ALL_TEAMS,
   DEPARTMENTS.ANALYTICS,

--- a/src/js/constants/DepartmentConstants.js
+++ b/src/js/constants/DepartmentConstants.js
@@ -1,11 +1,11 @@
 // DepartmentConstants.js
 export const DEPARTMENTS = {
   ALL_TEAMS: 'All teams',
-  ANALYTICS: 'Analytics',
-  DONATIONS: 'Donations',
-  ENGINEERING: 'Engineering',
+  ANALYTICS: 'Analytics Team',
+  DONATIONS: 'Donations Team',
+  ENGINEERING: 'Engineering Team',
   POLITICAL_DATA: 'Political Data',
-  OTHER: 'Other',
+  OTHER: 'Other team',
 };
 
 export const DEPARTMENT_LIST = [

--- a/src/js/constants/DepartmentConstants.js
+++ b/src/js/constants/DepartmentConstants.js
@@ -8,6 +8,7 @@ export const DEPARTMENTS = {
   OTHER: 'Other team',
 };
 
+
 export const DEPARTMENT_LIST = [
   DEPARTMENTS.ALL_TEAMS,
   DEPARTMENTS.ANALYTICS,

--- a/src/js/models/TaskModel.jsx
+++ b/src/js/models/TaskModel.jsx
@@ -139,7 +139,7 @@ export function captureTaskGroupListRetrieveData (
 }
 
 // This is called after making this fetchData request:
-// const taskStatusListRetrieveResults = useFetchData(['task-status-list-retrieve'], { personIdList: personIdsList });
+// const taskStatusListRetrieveResults = useFetchData(['task-status-list-retrieve'], { personIdList: personIdsList }, METHOD.POST);
 // TODO: Dale still thinking about this. Please leave this commented out code until April 2025
 export function captureTaskStatusListRetrieveData (
   incomingRetrieveResults = {},
@@ -213,12 +213,10 @@ export function captureTaskStatusListRetrieveData (
           // Task doesn't exist, so add it
           allTasksByDefinitionIdCacheNew[task.taskDefinitionId].push(task);
           newTaskListByDefinitionIdDataReceived = true;
-        } else {
+        } else if (!isEqual(allTasksByDefinitionIdCacheNew[task.taskDefinitionId][existingTaskIndex], task)) {
           // Task exists, update it if it's different
-          if (!isEqual(allTasksByDefinitionIdCacheNew[task.taskDefinitionId][existingTaskIndex], task)) {
-            allTasksByDefinitionIdCacheNew[task.taskDefinitionId][existingTaskIndex] = task;
-            newTaskListByDefinitionIdDataReceived = true;
-          }
+          allTasksByDefinitionIdCacheNew[task.taskDefinitionId][existingTaskIndex] = task;
+          newTaskListByDefinitionIdDataReceived = true;
         }
       }
     });

--- a/src/js/pages/SystemSettings/PermissionsAdministration.jsx
+++ b/src/js/pages/SystemSettings/PermissionsAdministration.jsx
@@ -135,7 +135,7 @@ const PermissionsAdministration = ({ classes }) => {
       person.isHiringManager === false && filterState.current.hiring === true &&
       person.isTeamLead === false && filterState.current.lead === true &&
       person.isIntern === false && filterState.current.intern === true &&
-      person.statusActive === false && filterState.current.active === true &&
+      (person.statusActive === false || person.statusActive === null) && filterState.current.active === true &&
       person.statusOnLeave === false && filterState.current.leave === true &&
       person.statusResigned === false && filterState.current.resigned === true &&
       person.statusAvailableForSpecialProjects === false && filterState.current.special === true;
@@ -470,7 +470,7 @@ const PermissionsAdministration = ({ classes }) => {
               </Td>
               <Td>
                 <Checkbox
-                  checked={person.statusActive}
+                  checked={person.statusActive === true}
                   className={classes.checkboxDoneRoot}
                   color="primary"
                   id={`checkbox-active-${person.id}`}

--- a/src/js/pages/SystemSettings/TaskGroup.jsx
+++ b/src/js/pages/SystemSettings/TaskGroup.jsx
@@ -60,7 +60,7 @@ const TaskGroup = ({ classes }) => {
     }
   }, [apiDataCache, dispatch, taskGroupListRetrieveResults]);
 
-  const taskStatusListRetrieveResults = useFetchData(['task-status-list-retrieve'], { personIdList: personIdsList }, METHOD.GET);
+  const taskStatusListRetrieveResults = useFetchData(['task-status-list-retrieve'], { personIdList: personIdsList }, METHOD.POST);
   useEffect(() => {
     if (taskStatusListRetrieveResults) {
       captureTaskStatusListRetrieveData(taskStatusListRetrieveResults, apiDataCache, dispatch);

--- a/src/js/pages/SystemSettings/TaskGroupListIndex.jsx
+++ b/src/js/pages/SystemSettings/TaskGroupListIndex.jsx
@@ -47,7 +47,7 @@ const TaskGroupListIndex = ({ classes, showTaskGroupList }) => {
     }
   }, [apiDataCache, dispatch, taskGroupListRetrieveResults]);
 
-  const taskStatusListRetrieveResults = useFetchData(['task-status-list-retrieve'], { personIdList: personIdsList }, METHOD.GET);
+  const taskStatusListRetrieveResults = useFetchData(['task-status-list-retrieve'], { personIdList: personIdsList }, METHOD.POST);
   useEffect(() => {
     if (taskStatusListRetrieveResults) {
       captureTaskStatusListRetrieveData(taskStatusListRetrieveResults, apiDataCache, dispatch);

--- a/src/js/pages/Tasks.jsx
+++ b/src/js/pages/Tasks.jsx
@@ -58,7 +58,7 @@ const Tasks = () => {
     }
   }, [apiDataCache, dispatch, taskGroupListRetrieveResults]);
 
-  const taskStatusListRetrieveResults = useFetchData(['task-status-list-retrieve'], { personIdList: personIdsList }, METHOD.GET);
+  const taskStatusListRetrieveResults = useFetchData(['task-status-list-retrieve'], { personIdList: personIdsList }, METHOD.POST);
   useEffect(() => {
     if (taskStatusListRetrieveResults) {
       captureTaskStatusListRetrieveData(taskStatusListRetrieveResults, apiDataCache, dispatch);

--- a/src/js/pages/Teams.jsx
+++ b/src/js/pages/Teams.jsx
@@ -126,7 +126,8 @@ const Teams = () => {
       const teamMemberPersonIdsSet = new Set(
         Object.values(allTeamMembersCache)
           .flat()
-          .map((teamMember) => teamMember.personId));
+          .map((teamMember) => teamMember.personId),
+      );
       const teamMemberPersonIds = Array.from(teamMemberPersonIdsSet);
       // console.log('teams useEffect, teamMemberPersonIds: ', teamMemberPersonIds);
       // Filter allPeople to get those not in any team
@@ -173,7 +174,7 @@ const Teams = () => {
         {DEPARTMENT_LIST.map((dept) => (
           <DepartmentFilterButton
             key={dept}
-            active={selectedDepartment === dept}
+            $active={selectedDepartment === dept}
             onClick={() => setSelectedDepartment(dept)}
           >
             {dept}
@@ -187,9 +188,9 @@ const Teams = () => {
         {/* We have partially implemented this change by introducing teamMemberInfoList */}
         {teamList.map((team) => {
           const teamIdentifier = team?.teamId || team?.id;
-          const teamMatchesDepartmentFilter = selectedDepartment === 'All teams' || 
+          const teamMatchesDepartmentFilter = selectedDepartment === 'All teams' ||
             (team.departments && team.departments.includes(selectedDepartment));
-          
+
           if (showTeam(team, searchText, getAppContextValue) && teamMatchesDepartmentFilter) {
             return (
               <OneTeamWrapper key={`team-${teamIdentifier}`}>
@@ -258,20 +259,20 @@ const DepartmentFilterHeader = styled('div')`
 `;
 
 const DepartmentFilterButton = styled('button')`
-  border: 1px solid ${props => props.active ? '#1e6fb9' : '#d0d0d0'};
-  background: ${props => props.active ? '#1e6fb9' : 'white'};
-  color: ${props => props.active ? 'white' : '#333'};
+  border: 1px solid ${(props) => (props.active ? '#1e6fb9' : '#d0d0d0')};
+  background: ${(props) => (props.active ? '#1e6fb9' : 'white')};
+  color: ${(props) => (props.active ? 'white' : '#333')};
   padding: 8px 20px;
   border-radius: 20px;
   font-size: 14px;
-  font-weight: ${props => props.active ? '600' : '500'};
+  font-weight: ${(props) => (props.active ? '600' : '500')};
   cursor: pointer;
   transition: all 0.2s ease;
   font-family: inherit;
 
   &:hover {
-    background: ${props => props.active ? '#1a5a94' : '#f5f5f5'};
-    border-color: ${props => props.active ? '#1a5a94' : '#b0b0b0'};
+    background: ${(props) => (props.active ? '#1a5a94' : '#f5f5f5')};
+    border-color: ${(props) => (props.active ? '#1a5a94' : '#b0b0b0')};
   }
 
   &:active {

--- a/src/js/react-query/WeConnectQuery.js
+++ b/src/js/react-query/WeConnectQuery.js
@@ -40,7 +40,7 @@ const weConnectQueryFn = async (queryKey, params, isGet, forceMaster = false) =>
   });
 
 
-  httpLog('HTTP weConnectQueryFn : ', JSON.stringify(res || {}));
+  httpLog(`HTTP weConnectQueryFn ${queryKey} (${isGet ? 'GET' : 'POST'}): ${JSON.stringify(res || {})}`);
   const url = new URL(`${queryKey}/`,
     forceMaster ? 'https://teamapi.wevote.org/apis/v1/' : webAppConfig.STAFF_API_SERVER_API_ROOT_URL);
   // console.log(queryKey, params, isGet);

--- a/src/js/react-query/WeConnectQuery.js
+++ b/src/js/react-query/WeConnectQuery.js
@@ -60,8 +60,9 @@ const weConnectQueryFn = async (queryKey, params, isGet, forceMaster = false) =>
       // TODO Consider showing this API error in the interface to the viewer
       console.error(`displayErrorMessage ${queryKey} status: ${response.data.status}`);
     }
-  } catch (e) {
-    console.error('Axios ', (isGet ? 'axios.get' : 'axios.post'), ' error: ', e);
+  } catch (err) {
+    const errorMsg = typeof err !== 'undefined' ? err : '';
+    console.error('Axios ', (isGet ? 'axios.get' : 'axios.post'), ' error: ', errorMsg);
   }
 
   return response?.data;
@@ -71,15 +72,21 @@ const useFetchData = (queryKey, fetchParams, isGet, shouldExecute = true, queryO
   if (shouldExecute) {
     reactQueryLog('useFetchData queryKey, fetchParams before fetch: ', queryKey, '  fetchParams: ', fetchParams);
   }
+
   const { data, isSuccess, isFetching, isStale, refetch, error } = useQuery({
     queryKey,
     queryFn: () => weConnectQueryFn(queryKey, fetchParams, isGet),
     enabled: shouldExecute,
     ...queryOptions,
+    // staleTime: shouldExecute ? 0 : '',
   });
   if (error) {
     console.log(`An error occurred with ${queryKey}: ${error.message}`);
   }
+  // if (queryKey === 'task-status-list-retrieve')   {
+  //   console.log(`-----${queryKey} isSuccess: ${isSuccess}, isStale: ${isStale}, refetch: ${refetch}`);
+  //   console.log(`+++++${queryKey} data: ${JSON.stringify(data)}`);
+  // }
   return { data, isSuccess, isFetching, isStale, refetch };
 };
 

--- a/src/js/react-query/makeRequestParams.js
+++ b/src/js/react-query/makeRequestParams.js
@@ -1,4 +1,4 @@
-const makeRequestParams = (plainParams, data) => {
+export function makeRequestParamsDictionary (plainParams, data) {
   // plainParams could also be considered lookup params
   const expandedParams = {};
   Object.keys(plainParams).forEach((key) => {
@@ -8,11 +8,16 @@ const makeRequestParams = (plainParams, data) => {
     expandedParams[`${key}ToBeSaved`] = data[key];
     expandedParams[`${key}Changed`] = 'true';
   });
+  return expandedParams;
+}
+
+// Make request string
+export default function makeRequestParams (plainParams, data) {
+  const expandedParams = makeRequestParamsDictionary(plainParams, data);
+
   const queryString = Object.entries(expandedParams)
     .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
     .join('&');
 
   return queryString;
-};
-
-export default makeRequestParams;
+}

--- a/src/js/utils/showPerson.js
+++ b/src/js/utils/showPerson.js
@@ -35,8 +35,9 @@ export const showPersonInMemberList = (person, searchTextLocal, getAppContextVal
   } else if (pigsCanFly) {
     // Used for testing while developing
     return true;
-  } else if (!person.statusActive) {
+  } else if (person.statusActive === false) {   // Mar 2026, Allow people with null statusActive through
     // Only show people marked with statusActive = false when searching
+    // Mar 2026: Hopefully we won't find null statusActive going forward, but treat these as true
     // Eventually weave in the ability to show as a "show" filter option
     return false;
   } else if (getAppContextValue('peopleFilterExactMatchVsLogicalOr') === 'LOGICAL_OR') {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,6 +47,7 @@ async function getStatusValues () {
     const hashURL = `https://github.com/wevote/weconnect-server/commit/${hash}`;
     const response = await fetch(hashURL);
     const text = await response.text();
+    console.log(`git_commit_hash: '${text}'`);
     const pr = text.match(/"Merge pull request (.*?)wevote/);
     stats.Pull_request = pr[1].slice(0, -2);
     const dateStringResults = text.match(/"committedDate":"(.*?)"/);


### PR DESCRIPTION
Fixes https://wevoteusa.atlassian.net/browse/WV-2553
Fixes https://wevoteusa.atlassian.net/browse/WV-2669
Fixes https://wevoteusa.atlassian.net/browse/WV-2668 

**REQUIRES SERVER SIDE CHANGE** https://github.com/wevote/weconnect-server/pull/124

**PROBLEM 1**
We were allowing person on the addToTeamListTemp in AddPersonDrawerMainContent who if added to the team, were not allowed to be displayed on the Team tab.  So now we won't display candidate team members if they are not statusActive or are statusResigned or are statusOfferWillNotBeMade.

**PROBLEM 2:**
Person save was sending a URL like this:
 https://wevotedeveloper.com:4500/apis/v1/person-save/?0=p&1=e&2=r&3=s&4=o&5=n&6=I&7=d&8=%3D&9=2&10=7&11=4&12=%26&13=f&14=i&15=r&16=s&17=t&18=N&19=a&20=m&21=e&22=T&23=o&24=B&25=e&26=S&27=a&28=v&29=e&30=d&31=%3D&32=M&33=e&34=g&35=a&36=n&37=%25&38=2&39=0&40=D&41=E&42=L&43=E&44=T&45=E&46=%25&47=2&48=0&49=2&50=%26&51=f&52=i&53=r&54=s&55=t&56=N&57=a&58=m&59=e&60=C&61=h&62=a&63=n&64=g&65=e&66=d&67=%3D&68=t&69=r&70=u&71=e

You can easily see these in the log by setting LOG_HTTP_REQUESTS to true in config.js

Possibly as a result of a library update breaking change, our code to handle URLs with search components is no longer are accepting concatenated string parameters (as a string), they now require dictionaries of parameters.  

Fixed it with
    personSave(makeRequestParamsDictionary(plainParams, data));

Also made the same fix for the following API queries that save data (and are HTTP GET requests that send the parameters on the url):
    questionaireSave
    personSave
    questionSave
    taskDefinitionSave
    taskGroupSave
    taskGroupTeamLinkSave
    saveTask

&emsp;&emsp;**There may be more of these, but I don't know all the intricacies of the app to find all of the instances.**
&emsp;&emsp;**I didn't want to change code of this type, that I could not test.**


**PROBLEM 3**
After lots of testing, I found that we were unable to save the text[] in the Teams departments columns in the form of '{"Engineering"}'.  For whatever reason it was being added by our code (and via PGAdmin4) as '{Engineering}' which worked for our app, but was invalid SQL and failed FastLoad.  So I changed the one-word department names to two-word names with a space and now they all save correctly, and once this change gets to the production server, I expect that fast load will work again.