### PR TITLE
Figured out why we had some API calls that looked like this with GET API calls: /apis/v1/questionnaire-responses-list-retrieve/?0=p&1=e&2=r&3=s&4=o&5=n&6=I&7=d&8=L&9=i&10  Fixed the problem in 3 places.

### DIFF
--- a/src/js/components/Questionnaire/QuestionnaireResponsesList.jsx
+++ b/src/js/components/Questionnaire/QuestionnaireResponsesList.jsx
@@ -24,7 +24,10 @@ const QuestionnaireResponsesList = ({ personId }) => {
   const [questionnaireList, setQuestionnaireList] = useState([]);
 
   // Although we are sending a list, there will only be one person id, if there were more, just append them with commas
-  const requestParams = `personIdList[]=${person.id}`;
+  // OLD: const requestParams = `personIdList[]=${person.id}`;
+  const requestParams = {
+    personIdList: [person.id],
+  };
 
   const questionnaireResponsesListRetrieveResults = useFetchData(['questionnaire-responses-list-retrieve'], requestParams, METHOD.GET);
   // const { data: dataQRL, isSuccess: isSuccessQRL, isFetching: isFetchingQRL } = responsesRetrieveResults;

--- a/src/js/pages/AnswerQuestions.jsx
+++ b/src/js/pages/AnswerQuestions.jsx
@@ -67,7 +67,11 @@ const AnswerQuestions = ({ classes, setShowHeaderFooter }) => {
     }
   }, [questionListRetrieveResults, allQuestionsCache]);
 
-  const requestParams = `personIdList[]=${personId}&questionnaireId=${questionnaireId}`;
+  // OLD: const requestParams = `personIdList[]=${personId}&questionnaireId=${questionnaireId}`;
+  const requestParams = {
+    personIdList: [personId],
+    questionnaireId,
+  };
   const answerListRetrieveResults = useFetchData(['questionnaire-responses-list-retrieve'], requestParams, METHOD.GET);
   useEffect(() => {
     if (answerListRetrieveResults) {

--- a/src/js/pages/QuestionnaireAnswers.jsx
+++ b/src/js/pages/QuestionnaireAnswers.jsx
@@ -47,7 +47,10 @@ const QuestionnaireAnswers = ({ classes }) => {
     }
   }, [questionListRetrieveResults, allQuestionsCache]);
 
-  const requestParams = `personIdList[]=${personId}`;
+  // OLD: const requestParams = `personIdList[]=${personId}`;
+  const requestParams = {
+    personIdList: [personId],
+  };
   const answersListRetrieveResults = useFetchData(['questionnaire-responses-list-retrieve'], requestParams, METHOD.GET, true,
     { refetchInterval: 120000, refetchIntervalInBackground: false });
   useEffect(() => {

--- a/src/js/react-query/WeConnectQuery.js
+++ b/src/js/react-query/WeConnectQuery.js
@@ -35,6 +35,7 @@ const buildSearchParams = (params = {}) => {
 // Define a default query function that will receive the query key
 const weConnectQueryFn = async (queryKey, params, isGet, forceMaster = false) => {
   const res = { queryKey, isGet, forceMaster };
+  // console.log('weConnectQueryFn queryKey: ', queryKey, ', params: ', params);
   Object.keys(params).forEach((key) => {
     res[key] = params[key];
   });

--- a/src/js/react-query/mutations.jsx
+++ b/src/js/react-query/mutations.jsx
@@ -52,7 +52,7 @@ const useQuestionSaveMutation = () => {
 const useAnswerListSaveMutation = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (params) => weConnectQueryFn('answer-list-save', params, METHOD.GET),
+    mutationFn: (params) => weConnectQueryFn('answer-list-save', params, METHOD.POST),
     onError: (error) => console.log('error in useAnswerListSaveMutation: ', error),
     onSuccess: () => {
       console.log('useAnswerListSaveMutation onSuccess true');


### PR DESCRIPTION
Figured out why we had some API calls that looked like this with GET API calls: /apis/v1/questionnaire-responses-list-retrieve/?0=p&1=e&2=r&3=s&4=o&5=n&6=I&7=d&8=L&9=i&10 
Fixed the problem in 3 places.