### PR TITLE
feat: add git_commit_hash to weconnect-client builds (WV-2298)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ jobs:
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
       - run: cp src/js/config-template.js src/js/config.js
+      - name: Write git_commit_hash
+        run: echo "${{ github.sha }}" > git_commit_hash
       - run: npm ci
       - run: npm run build --if-present
       - run: npm test

--- a/codebuild/buildspec.yaml
+++ b/codebuild/buildspec.yaml
@@ -16,6 +16,7 @@ phases:
     on-failure: ABORT
     commands:
       - echo Build started at $(date)
+      - echo $CODEBUILD_RESOLVED_SOURCE_VERSION > git_commit_hash
       - docker build -f docker/Dockerfile.prod -t $IMAGE_NAME .
   post_build:
     on-failure: ABORT

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -9,6 +9,7 @@ RUN npm run build
 FROM public.ecr.aws/nginx/nginx:latest
 COPY --from=builder /app/build /usr/share/nginx/html
 COPY docker/scripts/nginx.conf /etc/nginx/conf.d/default.conf
+COPY git_commit_hash /usr/share/nginx/html/git_commit_hash
 EXPOSE 8000
 CMD ["nginx", "-g", "daemon off;"]
 


### PR DESCRIPTION
## Summary

Mirrors the existing pattern in WeVoteServer to make the deployed commit hash visible at runtime.

## Changes

- **`codebuild/buildspec.yaml`** — write `$CODEBUILD_RESOLVED_SOURCE_VERSION` to a `git_commit_hash` file during the build phase
- **`docker/Dockerfile.prod`** — copy `git_commit_hash` into the nginx image at `/usr/share/nginx/html/git_commit_hash`

After deploy, the running commit hash is accessible at `/git_commit_hash` on any weconnect-client instance.

Fixes [WV-2298](https://wevoteusa.atlassian.net/browse/WV-2298)

[WV-2298]: https://wevoteusa.atlassian.net/browse/WV-2298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ