### PR TITLE
fix: use GitHub REST API instead of HTML scraping in webpack.config.js (WV-4233)

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,28 +44,44 @@ async function getStatusValues () {
   try {
     console.log('Working Directory: ', __dirname);
     let hash = fs.readFileSync('./git_commit_hash', 'utf8');
-    console.log('Hash: ', hash);
     hash = hash.trim();
+    console.log('Hash: ', hash);
     const hashURL = `https://github.com/wevote/weconnect-client/commit/${hash}`;
     console.log('hashURL: ', hashURL);
-    const response = await fetch(hashURL);
-    const text = await response.text();
-    console.log(`git_commit_hash: '${text}'`);
-    if (text !== 'Not Found') {
-      const pr = text.match(/"Merge pull request (.*?)wevote/);
-      stats.Pull_request = pr[1].slice(0, -2);
-      const dateStringResults = text.match(/"committedDate":"(.*?)"/);
-      console.log(dateStringResults[1]);
-      const date = new DateTime(dateStringResults[1]);
-      stats.Git_committed_date = date.toLocaleString(DateTime.DATETIME_MED_WITH_SECONDS);
-      stats.Git_commit_hash = `<a href="${hashURL}">${hash}</a>`;
+
+    // Use the GitHub REST API instead of scraping HTML — works for all commit types
+    const apiHeaders = { 'Accept': 'application/vnd.github.v3+json', 'User-Agent': 'weconnect-client-build' };
+
+    // Get commit details (date)
+    const commitResponse = await fetch(`https://api.github.com/repos/wevote/weconnect-client/commits/${hash}`, { headers: apiHeaders });
+    if (!commitResponse.ok) {
+      throw new Error(`GitHub API returned ${commitResponse.status} for commit ${hash}`);
+    }
+    const commitData = await commitResponse.json();
+    const committedDate = commitData.commit.committer.date || commitData.commit.author.date;
+    console.log('committedDate: ', committedDate);
+    const date = new DateTime(committedDate);
+    stats.Git_committed_date = date.toLocaleString(DateTime.DATETIME_MED_WITH_SECONDS);
+    stats.Git_commit_hash = `<a href="${hashURL}">${hash}</a>`;
+
+    // Get associated pull request number
+    const prsResponse = await fetch(`https://api.github.com/repos/wevote/weconnect-client/commits/${hash}/pulls`, { headers: apiHeaders });
+    if (prsResponse.ok) {
+      const prs = await prsResponse.json();
+      if (prs.length > 0) {
+        stats.Pull_request = `#${prs[0].number}`;
+        console.log('Pull_request: ', stats.Pull_request);
+      } else {
+        stats.Pull_request = 'none';
+      }
     } else {
       stats.Pull_request = 'none';
-      stats.Git_committed_date = 'none';
-      stats.Git_commit_hash = 'Not Found';
     }
   } catch (error) {
     console.log('Error in getStatusValues git: ', error);
+    stats.Pull_request = 'none';
+    stats.Git_committed_date = 'none';
+    stats.Git_commit_hash = 'none';
   }
 
   return stats;


### PR DESCRIPTION
## Problem

The `getStatusValues()` function in `webpack.config.js` was fetching the full GitHub commit HTML page and regex-scraping it for PR number and committed date:

```js
const response = await fetch(hashURL);  // fetches full HTML page
const text = await response.text();
const pr = text.match(/"Merge pull request (.*?)wevote/);  // fails on non-merge commits
```

This silently fails for any non-merge commit (PR branch builds, direct commits) because the regex doesn't match, causing an unhandled exception. Observed in CI from PR #150:

```
Hash:  2719797dc2b01b47e385ee4639057c5c6504f62f
git_commit_hash: '
  <script type="application/json" id="client-env">...  ← got full HTML, not the hash
```

## Fix

Replace HTML scraping with two GitHub REST API calls (no auth required for public repos):

1. `GET /repos/wevote/weconnect-client/commits/{hash}` — gets committed date
2. `GET /repos/wevote/weconnect-client/commits/{hash}/pulls` — gets associated PR number

This works correctly for all commit types: merge commits, direct commits, and PR branch builds. Also adds proper error fallbacks so `WEBPACK_PULL_REQUEST`, `WEBPACK_GIT_DATE`, and `WEBPACK_GIT_HASH` always have a defined value.

Fixes [WV-4233](https://wevoteusa.atlassian.net/browse/WV-4233)
Related: #150

[WV-4233]: https://wevoteusa.atlassian.net/browse/WV-4233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ