### PR TITLE
[WV-4251]When searching for a person, the donorsOnTeam value gets very large [Team Review]

### DIFF
--- a/src/js/components/Team/TeamHeader.jsx
+++ b/src/js/components/Team/TeamHeader.jsx
@@ -98,15 +98,15 @@ const TeamHeader = (
       if (teamMember && teamMember.personId && teamMember.personId >= 0) {
         const person = allPeopleCache[teamMember.personId];
         if (person && person.id) {
-          if (isPersonActive(person) || !hideInactive) {
+          if (showPersonInMemberList(person, searchText, getAppContextValue) && (isPersonActive(person) || !hideInactive)) {
             if (teamMember.isTeamLead) {
               teamLeadsTemp += `${person.firstNamePreferred || person.firstName}, `;
               teamLeadsCountTemp += 1;
             }
-          }
-          if (isPersonActive(person)) {
-            if (person.isMonthlyDonor) {
-              donorsOnTeamTemp += 1;
+            if (isPersonActive(person)) {
+              if (person.isMonthlyDonor) {
+                donorsOnTeamTemp += 1;
+              }
             }
           }
         }
@@ -118,7 +118,7 @@ const TeamHeader = (
 
     setTeamLeads(teamLeadsTemp);
     setTeamLeadsCount(teamLeadsCountTemp);
-  }, [apiDataCache, team]);
+  }, [apiDataCache, team, searchText, hideInactive, getAppContextValue]);
 
   useEffect(() => {
     let numberOfTeamMembersTemp = 0;

--- a/src/js/components/Team/TeamHeader.jsx
+++ b/src/js/components/Team/TeamHeader.jsx
@@ -142,9 +142,7 @@ const TeamHeader = (
         if (person.emailPersonal) {
           personalEmails += `${person.emailPersonal}, `;
         }
-
       }
-
     });
 
     // Remove trailing comma and space
@@ -162,7 +160,6 @@ const TeamHeader = (
     }
     try {
       const donorPercent = Math.round((donorsOnTeam / numberOfTeamMembers) * 100);
-      console.log("team member count with team name and donors on team with %:",donorPercent,donorsOnTeam,numberOfTeamMembers,team)
       if (Number.isNaN(donorPercent)) {
         return '';
       }

--- a/src/js/components/Team/TeamHeader.jsx
+++ b/src/js/components/Team/TeamHeader.jsx
@@ -98,15 +98,15 @@ const TeamHeader = (
       if (teamMember && teamMember.personId && teamMember.personId >= 0) {
         const person = allPeopleCache[teamMember.personId];
         if (person && person.id) {
-          if (showPersonInMemberList(person, searchText, getAppContextValue) && (isPersonActive(person) || !hideInactive)) {
+          if (isPersonActive(person) || !hideInactive) {
             if (teamMember.isTeamLead) {
               teamLeadsTemp += `${person.firstNamePreferred || person.firstName}, `;
               teamLeadsCountTemp += 1;
             }
-            if (isPersonActive(person)) {
-              if (person.isMonthlyDonor) {
-                donorsOnTeamTemp += 1;
-              }
+          }
+          if (isPersonActive(person)) {
+            if (person.isMonthlyDonor) {
+              donorsOnTeamTemp += 1;
             }
           }
         }
@@ -118,7 +118,7 @@ const TeamHeader = (
 
     setTeamLeads(teamLeadsTemp);
     setTeamLeadsCount(teamLeadsCountTemp);
-  }, [apiDataCache, team, searchText, hideInactive, getAppContextValue]);
+  }, [apiDataCache, team]);
 
   useEffect(() => {
     let numberOfTeamMembersTemp = 0;
@@ -130,6 +130,11 @@ const TeamHeader = (
     }
 
     updatedTeamMemberPersonList.forEach((person) => {
+
+      if (showPersonInMemberList(person, null, getAppContextValue) && (isPersonActive(person) || !hideInactive)) {
+        numberOfTeamMembersTemp += 1;
+      }
+
       if (showPersonInMemberList(person, searchText, getAppContextValue) && (isPersonActive(person) || !hideInactive)) {
         if (person.emailOfficial) {
           officialEmails += `${person.emailOfficial}, `;
@@ -137,8 +142,9 @@ const TeamHeader = (
         if (person.emailPersonal) {
           personalEmails += `${person.emailPersonal}, `;
         }
-        numberOfTeamMembersTemp += 1;
+
       }
+
     });
 
     // Remove trailing comma and space
@@ -156,6 +162,7 @@ const TeamHeader = (
     }
     try {
       const donorPercent = Math.round((donorsOnTeam / numberOfTeamMembers) * 100);
+      console.log("team member count with team name and donors on team with %:",donorPercent,donorsOnTeam,numberOfTeamMembers,team)
       if (Number.isNaN(donorPercent)) {
         return '';
       }

--- a/src/js/components/Team/TeamHeader.jsx
+++ b/src/js/components/Team/TeamHeader.jsx
@@ -130,7 +130,6 @@ const TeamHeader = (
     }
 
     updatedTeamMemberPersonList.forEach((person) => {
-
       if (showPersonInMemberList(person, null, getAppContextValue) && (isPersonActive(person) || !hideInactive)) {
         numberOfTeamMembersTemp += 1;
       }


### PR DESCRIPTION
### What github.com/wevote/weconnect/issues does this fix?
[WV4251]When searching for a person, the donorsOnTeam value gets very large

### Changes included this pull request?

src/js/components/Team/TeamHeader.jsx

Fixed the numberOfTeamMembers value so it correctly ignores the search text. Previously, the count was being updated based on filtered results, which caused it to change when a search was applied.

In the comparison below, the donor percentage is now displayed correctly. The left side shows the behavior before the fix (from the QA WeConnect client), while the right side shows the corrected behavior after applying the fix (from the local WeConnect client).

<img width="1394" height="1019" alt="image" src="https://github.com/user-attachments/assets/53fd58f6-3a0a-42c1-b4b5-aac8760e5911" />

