### PR TITLE
[WV-2562] WeConnect: Profile start and end dates entered don't match summary information [TeamReview]

### DIFF
--- a/src/js/components/Person/PersonDetailsEmailsAndStartDate.jsx
+++ b/src/js/components/Person/PersonDetailsEmailsAndStartDate.jsx
@@ -58,8 +58,8 @@ const PersonDetailsEmailsAndStartDate = ({ person, teamId }) => {
 
   const canEditPerson = viewerCanSeeOrDo(['canEditPersonAnyone'], viewerAccessRights) || viewerCanSeeOrDoForThisTeam('canEditPersonThisTeam', teamId, viewerTeamAccessRights);
   const preferredEmail = person.emailPreferred || person.emailOfficial || '';
-  const formattedEndDate = person.dateEndDate ? new Date(person.dateEndDate).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' }) : '';
-  const formattedStartDate = person.dateStartDate ? new Date(person.dateStartDate).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' }) : '';
+  const formattedEndDate = person.dateEndDate ? new Date(person.dateEndDate).toLocaleDateString('en-US', { timeZone: 'UTC', month: 'long', day: 'numeric', year: 'numeric' }) : '';
+  const formattedStartDate = person.dateStartDate ? new Date(person.dateStartDate).toLocaleDateString('en-US', { timeZone: 'UTC', month: 'long', day: 'numeric', year: 'numeric' }) : '';
   return (
     <PersonDetailsEmailsAndStartDateWrapper>
       {preferredEmail && (


### PR DESCRIPTION
### What github.com/wevote/weconnect/issues does this fix?
[WV-2562] WeConnect: Profile start and end dates entered don't match summary information
### Changes included this pull request?
src/js/components/Person/PersonDetailsEmailsAndStartDate.jsx

Fixed a date mismatch caused by time zone differences during string conversion.
<img width="1514" height="474" alt="startenddate1_20260414" src="https://github.com/user-attachments/assets/bdcc2aa0-e96d-45a9-ae8e-195049046afd" />
<img width="839" height="785" alt="startenddate_20260414" src="https://github.com/user-attachments/assets/a29e74f8-7fec-49a0-b1f5-fdc944fdc3dd" />


[WV-2562]: https://wevoteusa.atlassian.net/browse/WV-2562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ