### PR TITLE
WV-2636 implementation + login intermittent race condition bugfix

### DIFF
--- a/src/js/models/AuthModel.jsx
+++ b/src/js/models/AuthModel.jsx
@@ -8,7 +8,8 @@ export const viewerCanSeeOrDoOneAccessRight = (accessRightName, viewerAccessRigh
   if (!viewerAccessRights || !(accessRightName in viewerAccessRights)) {
     return false;
   }
-  return viewerAccessRights[accessRightName] || false;
+  let canSeeOrDoOneAccessRight = viewerAccessRights[accessRightName] || false;
+  return canSeeOrDoOneAccessRight;
 };
 
 export const viewerCanSeeOrDo = (accessRightNameList, viewerAccessRights) => {

--- a/src/js/pages/Login.jsx
+++ b/src/js/pages/Login.jsx
@@ -59,6 +59,8 @@ const Login = ({ classes }) => {
       authPerson.current = authenticatedPerson;
       if (authenticatedPerson) {
         setAppContextValue('isAuthenticated', isAuthenticated);
+        // console.log("authPerson: " + JSON.stringify(authPerson));
+        // console.log("isAuthenticated: " + getAppContextData('isAuthenticated'));
       }
       captureAccessRightsData(dataAuth, isSuccessAuth, apiDataCache, dispatch);
       if (!emailVerifiedFromAPI && personId > 0) {
@@ -110,7 +112,7 @@ const Login = ({ classes }) => {
         data.person.personId = data.person.id;    // Initialize legacy (redundant) 'personId' field, which is not in the database
       }
       setAppContextValue('authenticatedPerson', data.person);
-      queryClient.invalidateQueries('get-auth');
+      queryClient.invalidateQueries({ queryKey: ['get-auth'] });
       if (data.emailVerified) {
         passwordFldRef.current = '';   // Blank the email field after signing in
         setWarningLine('');
@@ -181,7 +183,6 @@ const Login = ({ classes }) => {
     } else {
       setWarningLine('');
       setSuccessLine('You are signed out');
-      mutateLogout();
     }
   };
 
@@ -311,13 +312,17 @@ const Login = ({ classes }) => {
     event.preventDefault();
   };
 
-  // console.log(getAppContextData());
-  const isAdmin = viewerCanSeeOrDo(['canAddTeamMemberAnyTeam'], viewerAccessRights);
   // const isAuthSafe = getAppContextValue('isAuthenticated') || false;
   let isAuthenticated = false;
   let authenticatedPerson = {};
+  let isAdmin = false;
   if (dataAuth) {
     ({ isAuthenticated, person: authenticatedPerson } = dataAuth);
+    let apTemp = getAppContextValue('authenticatedPerson');
+    if (apTemp !== undefined && apTemp !== null && apTemp.isAdmin !== undefined && apTemp.isAdmin !== null) {
+      isAdmin = apTemp.isAdmin;
+    }
+
   }
   const displayVerify =
     !isForSomeOneElse &&
@@ -326,7 +331,7 @@ const Login = ({ classes }) => {
     getAppContextValue('secretCodeVerified') !== true &&
     (getAppContextValue('openVerifySecretCodeModalDialog') || false);
 
-  // console.log('login before return render, getAppContextData()', getAppContextData());
+  console.log('login before return render, getAppContextData()', getAppContextData());
   return (
     <div>
       <Helmet>

--- a/src/js/pages/SystemSettings/QuestionnaireListIndex.jsx
+++ b/src/js/pages/SystemSettings/QuestionnaireListIndex.jsx
@@ -63,7 +63,7 @@ const QuestionnaireListIndex = ({ classes, showQuestionnaireList }) => {
   const goToQuestionnairePageClick = (questionnaire) => {
     setAppContextValue('selectedQuestionnaire', questionnaire);
 
-    queryClient.invalidateQueries(['question-list-retrieve']).then(() => {});
+    queryClient.invalidateQueries({ queryKey: ['question-list-retrieve'] }).then(() => {});
     // console.log('goToQuestionnairePageClick = (questionnaire)', questionnaire.questionnaireId);
 
     navigate(`/questionnaire/${questionnaire.questionnaireId}`);

--- a/src/js/pages/SystemSettings/SystemSettings.jsx
+++ b/src/js/pages/SystemSettings/SystemSettings.jsx
@@ -12,6 +12,8 @@ import { viewerCanSeeOrDo } from '../../models/AuthModel';
 import capturePersonListRetrieveData from '../../models/capturePersonListRetrieveData';
 import { captureTaskDefinitionListRetrieveData, captureTaskGroupListRetrieveData, captureTaskStatusListRetrieveData } from '../../models/TaskModel';
 import { METHOD, useFetchData } from '../../react-query/WeConnectQuery';
+import useRedirectToLoginIfLoggedOut from '../../utils/useRedirectToLoginIfLoggedOut';
+
 
 const SystemSettings = () => {
   renderLog('SystemSettings');
@@ -23,6 +25,9 @@ const SystemSettings = () => {
   const [personIdsList, setPersonIdsList] = useState([]);
 
   const personListRetrieveResults = useFetchData(['person-list-retrieve'], {}, METHOD.GET);
+  const API_RETRIEVE_ERRORS_IN_A_ROW_THRESHOLD = 30;
+  useRedirectToLoginIfLoggedOut(personListRetrieveResults, API_RETRIEVE_ERRORS_IN_A_ROW_THRESHOLD); //or maybe taskDefinitionListRetrieveResults or taskGroupListRetrieveResults or taskStatusListRetrieveResults?
+
   useEffect(() => {
     if (personListRetrieveResults) {
       capturePersonListRetrieveData(personListRetrieveResults, apiDataCache, dispatch);

--- a/src/js/pages/Tasks.jsx
+++ b/src/js/pages/Tasks.jsx
@@ -20,6 +20,7 @@ import { alphabetizePeoplesObject } from '../utils/utilities';
 import { showTaskDefinition } from '../utils/showTask';
 import TaskSummaryRow from '../components/Task/TaskSummaryRow';
 import convertToInteger from '../common/utils/convertToInteger';
+import useRedirectToLoginIfLoggedOut from '../utils/useRedirectToLoginIfLoggedOut';
 
 
 const Tasks = () => {
@@ -38,6 +39,7 @@ const Tasks = () => {
   const [taskDefinitionList, setTaskDefinitionList] = useState([]);
 
   const personListRetrieveResults = useFetchData(['person-list-retrieve'], {}, METHOD.GET);
+
   useEffect(() => {
     if (personListRetrieveResults) {
       capturePersonListRetrieveData(personListRetrieveResults, apiDataCache, dispatch);
@@ -71,6 +73,9 @@ const Tasks = () => {
       captureTeamListRetrieveData(teamListRetrieveResults, apiDataCache, dispatch);
     }
   }, [teamListRetrieveResults]);
+
+  const API_RETRIEVE_ERRORS_IN_A_ROW_THRESHOLD = 30;
+  useRedirectToLoginIfLoggedOut(teamListRetrieveResults, API_RETRIEVE_ERRORS_IN_A_ROW_THRESHOLD);
 
   useEffect(() => {
     // console.log('Tasks useEffect allPeopleCache:', allPeopleCache);

--- a/src/js/pages/Teams.jsx
+++ b/src/js/pages/Teams.jsx
@@ -1,5 +1,5 @@
 import { withStyles } from '@mui/styles';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import styled from 'styled-components';
 import arrayContains from '../common/utils/arrayContains';
@@ -14,6 +14,8 @@ import { METHOD, useFetchData } from '../react-query/WeConnectQuery';
 import { showPersonInMemberList } from '../utils/showPerson';
 import { showCohortTeam, showTeam } from '../utils/showTeam';
 import { DEPARTMENTS, DEPARTMENT_LIST } from '../constants/DepartmentConstants';
+import { SettingsApplications } from '@mui/icons-material';
+import useRedirectToLoginIfLoggedOut from '../utils/useRedirectToLoginIfLoggedOut';
 
 
 const Teams = () => {
@@ -29,19 +31,25 @@ const Teams = () => {
   const [statusNotOnTeamCohortMemberList, setStatusNotOnTeamCohortMemberList] = useState([]);
   const [statusOfferDecisionNeededCohortMemberList, setStatusOfferDecisionNeededCohortMemberList] = useState([]);
   const [teamList, setTeamList] = useState([]);
+  const [apiRetrieveErrorsInARowCount, setApiRetrieveErrorsInARowCount] = useState(0);
 
   const personListRetrieveResults = useFetchData(['person-list-retrieve'], {}, METHOD.GET);
+
   useEffect(() => {
     // console.log('useFetchData person-list-retrieve in Teams useEffect:', personListRetrieveResults);
     if (personListRetrieveResults) {
-      // console.log('In useEffect apiDataCache:', apiDataCache);
+      console.log('In useEffect apiDataCache:', apiDataCache);
       // const changeResults =
       capturePersonListRetrieveData(personListRetrieveResults, apiDataCache, dispatch);
-      // console.log('ConnectAppContext useEffect capturePersonListRetrieveData changeResults:', changeResults);
+      //console.log('ConnectAppContext useEffect capturePersonListRetrieveData changeResults:', changeResults);
     }
   }, [personListRetrieveResults, allPeopleCache, dispatch]);
 
   const teamListRetrieveResults = useFetchData(['team-list-retrieve'], {}, METHOD.GET);
+  const API_RETRIEVE_ERRORS_IN_A_ROW_THRESHOLD = 50;
+  useRedirectToLoginIfLoggedOut(teamListRetrieveResults, API_RETRIEVE_ERRORS_IN_A_ROW_THRESHOLD);
+
+
   // ////////////////////////////////////////////
   // Dale's approach to use organize incoming data and then use that data from apiDataCache
   // Allows us to organize incoming data independent of the specific API, potentially from multiple API or sources

--- a/src/js/react-query/mutations.jsx
+++ b/src/js/react-query/mutations.jsx
@@ -8,7 +8,7 @@ const useRemoveTeamMutation = () => {
   return useMutation({
     mutationFn: (params) => weConnectQueryFn('team-delete', params, METHOD.GET),
     onError: (error) => console.log('error in useRemoveTeamMutation: ', error),
-    onSuccess: () => queryClient.invalidateQueries('team-list-retrieve'),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['team-list-retrieve'] }),
   });
 };
 
@@ -18,7 +18,7 @@ const useRemoveTeamMemberMutation = () => {
   return useMutation({
     mutationFn: (params) => weConnectQueryFn('remove-person-from-team', params, METHOD.GET),
     onError: (error) => console.log('error in useRemoveTeamMemberMutation: ', error),
-    onSuccess: () => queryClient.invalidateQueries('team-list-retrieve'),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['team-list-retrieve'] }),
   });
 };
 
@@ -27,7 +27,7 @@ const useAddPersonToTeamMutation = () => {
   return useMutation({
     mutationFn: (params) => weConnectQueryFn('add-person-to-team', params, METHOD.GET),
     onError: (error) => console.log('error in addPersonToTeamMutation: ', error),
-    onSuccess: () => queryClient.invalidateQueries('team-list-retrieve'),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['team-list-retrieve'] }),
   });
 };
 
@@ -36,7 +36,7 @@ const useQuestionListSaveMutation = () => {
   return useMutation({
     mutationFn: (params) => weConnectQueryFn('question-list-save', params, METHOD.GET),
     onError: (error) => console.log('error in useQuestionListSaveMutation: ', error),
-    onSuccess: () => queryClient.invalidateQueries('question-list-retrieve'),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['question-list-retrieve'] }),
   });
 };
 
@@ -45,7 +45,7 @@ const useQuestionSaveMutation = () => {
   return useMutation({
     mutationFn: (params) => weConnectQueryFn('question-save', params, METHOD.GET),
     onError: (error) => console.log('error in useQuestionSaveMutation: ', error),
-    onSuccess: () => queryClient.invalidateQueries('question-list-retrieve'),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['question-list-retrieve'] }),
   });
 };
 
@@ -58,12 +58,12 @@ const useAnswerListSaveMutation = () => {
       console.log('useAnswerListSaveMutation onSuccess true');
       // We request a fresh person-list-retrieve because some questionnaire responses get saved to the person table.
       // This can be optimized to be conditional and only request person-list-retrieve for questionnaires that update the person table.
-      queryClient.invalidateQueries('person-list-retrieve');
+      queryClient.invalidateQueries({ queryKey: ['person-list-retrieve'] });
 
       queryClient.invalidateQueries({
         queryKey: ['questionnaire-responses-list-retrieve'],
       });
-      queryClient.invalidateQueries('task-status-list-retrieve');
+      queryClient.invalidateQueries({ queryKey: ['task-status-list-retrieve'] });
       // TODO BUG: For some reason, neither of these invalidateQueries are causing an immediate re-fetch of the data.
     },
   });
@@ -74,7 +74,7 @@ const useQuestionnaireSaveMutation = () => {
   return useMutation({
     mutationFn: (params) => weConnectQueryFn('questionnaire-save', params, METHOD.GET),
     onError: (error) => console.log('error in useQuestionnaireSaveMutation: ', error),
-    onSuccess: () => queryClient.invalidateQueries('questionnaire-list-retrieve'),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['questionnaire-list-retrieve'] }),
   });
 };
 
@@ -84,7 +84,7 @@ const useTaskDefinitionSaveMutation = () => {
     mutationFn: (params) => weConnectQueryFn('task-definition-save', params, METHOD.GET),
     onError: (error) => console.log('error in useTaskDefinitionSaveMutation: ', error),
     // onSuccess: () => queryClient.invalidateQueries('task-status-list-retrieve'),
-    onSuccess: () => queryClient.invalidateQueries('task-group-retrieve'),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['task-group-retrieve'] }),
   });
 };
 
@@ -92,7 +92,7 @@ const useTaskGroupTeamLinkDeleteMutation = () => {
   const queryClient = useQueryClient();
   return useMutation({ mutationFn: (params) => weConnectQueryFn('task-group-team-link-delete', params, METHOD.GET),
     onError: (error) => console.log('error in useTaskGroupTeamLinkDeleteMutation: ', error),
-    onSuccess: () => queryClient.invalidateQueries('task-group-team-link-list-retrieve'),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['task-group-team-link-list-retrieve'] }),
   });
 };
 
@@ -100,7 +100,7 @@ const useTaskGroupTeamLinkSaveMutation = () => {
   const queryClient = useQueryClient();
   return useMutation({ mutationFn: (params) => weConnectQueryFn('task-group-team-link-save', params, METHOD.GET),
     onError: (error) => console.log('error in useTaskGroupTeamLinkSaveMutation: ', error),
-    onSuccess: () => queryClient.invalidateQueries('task-group-team-link-list-retrieve'),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['task-group-team-link-list-retrieve'] }),
   });
 };
 
@@ -108,7 +108,7 @@ const useTaskGroupSaveMutation = () => {
   const queryClient = useQueryClient();
   return useMutation({ mutationFn: (params) => weConnectQueryFn('task-group-save', params, METHOD.GET),
     onError: (error) => console.log('error in useTaskGroupSaveMutation: ', error),
-    onSuccess: () => queryClient.invalidateQueries('task-group-retrieve'),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['task-group-retrieve'] }),
   });
 };
 
@@ -117,7 +117,7 @@ const useMeetingSaveMutation = () => {
   return useMutation({
     mutationFn: (params) => weConnectQueryFn('meeting-save', params, METHOD.GET),
     onError: (error) => console.log('error in useMeetingSaveMutation: ', error),
-    onSuccess: () => queryClient.invalidateQueries('meeting-list-retrieve'),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['meeting-list-retrieve'] }),
   });
 };
 
@@ -126,7 +126,7 @@ const usePersonAwaySaveMutation = () => {
   return useMutation({
     mutationFn: (params) => weConnectQueryFn('person-away-save', params, METHOD.GET),
     onError: (error) => console.log('error in usePersonAwaySaveMutation: ', error),
-    onSuccess: () => queryClient.invalidateQueries('person-away-list-retrieve'),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['person-away-list-retrieve'] }),
   });
 };
 
@@ -137,7 +137,7 @@ const usePersonSaveMutation = () => {
   return useMutation({
     mutationFn: (params) => weConnectQueryFn('person-save', params, METHOD.GET),
     onError: (error) => console.log('error in personSaveMutation: ', error),
-    onSuccess: () => queryClient.invalidateQueries('team-list-retrieve'),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['team-list-retrieve'] }),
   });
 };
 
@@ -147,7 +147,7 @@ const useSaveTaskMutation = () => {
   return useMutation({
     mutationFn: (requestParams) => weConnectQueryFn('task-save', requestParams, METHOD.GET),
     onError: (error) => console.log('error in useSaveTaskMutation: ', error),
-    onSuccess: () => queryClient.invalidateQueries('task-status-list-retrieve').then(() => {}),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['task-status-list-retrieve'] }).then(() => {}),
   });
 };
 
@@ -156,7 +156,7 @@ const useLogoutMutation = () => {
   return useMutation({
     mutationFn: () => weConnectQueryFn('logout', {}, METHOD.POST),
     onError: (error) => console.log('error in useLogoutMutation: ', error),
-    onSuccess: () => queryClient.invalidateQueries('get-auth'),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['get-auth'] }),
   });
 };
 

--- a/src/js/utils/useRedirectToLoginIfLoggedOut.js
+++ b/src/js/utils/useRedirectToLoginIfLoggedOut.js
@@ -1,0 +1,42 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router';
+import { useConnectAppContext } from '../contexts/ConnectAppContext';
+
+// Because we don't yet have an API endpoint to check session status, we infer
+// a logged-out session by counting consecutive failures on endpoints that
+// require an active login. The threshold is intentionally high (50) because
+// occasional errors happen even when logged in; 15 was too trigger-happy.
+// const API_RETRIEVE_ERRORS_IN_A_ROW_THRESHOLD = 50;
+// Teams = 50, other pages make fewer requests and are set to 30, shouldn't be less than about 20.
+// Number might have to change in the future if/when the back-end requests etc are changed.
+// Now it's an argument rather than a constant.
+
+const useRedirectToLoginIfLoggedOut = (retrieveResults, retrieveErrorsThreshold) => {
+  const API_RETRIEVE_ERRORS_IN_A_ROW_THRESHOLD = retrieveErrorsThreshold;
+  const { apiDataCache, getAppContextValue, setAppContextValue } = useConnectAppContext();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!retrieveResults) return;
+    if (retrieveResults.isSuccess === false) {
+      if (getAppContextValue('apiRetrieveErrorsInARowCount') === null) {
+        setAppContextValue('apiRetrieveErrorsInARowCount', 0);
+      }
+      setAppContextValue('apiRetrieveErrorsInARowCount', getAppContextValue('apiRetrieveErrorsInARowCount') + 1);
+      // console.log(`apiRetrieveErrorsInARowCount: ${getAppContextValue('apiRetrieveErrorsInARowCount')}`);
+      if (getAppContextValue('apiRetrieveErrorsInARowCount') >= API_RETRIEVE_ERRORS_IN_A_ROW_THRESHOLD &&
+        apiDataCache.viewerAccessRights !== null &&
+        apiDataCache.viewerAccessRights.canAddPerson !== null
+      ) {
+        setAppContextValue('apiRetrieveErrorsInARowCount', 0);
+        navigate('/login');
+        navigate(0);
+      }
+    } else if (retrieveResults.isSuccess === true && getAppContextValue('apiRetrieveErrorsInARowCount') !== 0) {
+      setAppContextValue('apiRetrieveErrorsInARowCount', 0);
+      // console.log(`apiRetrieveErrorsInARowCount: ${getAppContextValue('apiRetrieveErrorsInARowCount')}`);
+    }
+  }, [retrieveResults]); // eslint-disable-line react-hooks/exhaustive-deps
+};
+
+export default useRedirectToLoginIfLoggedOut;


### PR DESCRIPTION
## Summary

- Implements [WV-2636](https://wevoteusa.atlassian.net/browse/WV-2636): redirects the user to the login page when their session has expired / they are logged out. Extracted into a reusable `useRedirectToLoginIfLoggedOut` hook applied to the Teams, Tasks, and SystemSettings pages.
- Fixes an intermittent race-condition bug discovered while working on WV-2636, where the user would occasionally be logged out immediately after logging in.
- Updates the React Query v3/v4 `invalidateQueries` syntax to the v5 syntax.

## Test plan

- [ ] Expire/invalidate the session and confirm the user is redirected to `/login` from Teams, Tasks, and SystemSettings
- [ ] Log in repeatedly and confirm the user is no longer intermittently logged out immediately after login
- [ ] Confirm `invalidateQueries` calls still correctly trigger refetches after the v5 syntax migration

[WV-2636]: https://wevoteusa.atlassian.net/browse/WV-2636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ