### PR TITLE
WV-2636 follow-up: raise login-redirect error threshold to 200 for mobile

### DIFF
--- a/src/js/pages/SystemSettings/SystemSettings.jsx
+++ b/src/js/pages/SystemSettings/SystemSettings.jsx
@@ -25,7 +25,7 @@ const SystemSettings = () => {
   const [personIdsList, setPersonIdsList] = useState([]);
 
   const personListRetrieveResults = useFetchData(['person-list-retrieve'], {}, METHOD.GET);
-  const API_RETRIEVE_ERRORS_IN_A_ROW_THRESHOLD = 30;
+  const API_RETRIEVE_ERRORS_IN_A_ROW_THRESHOLD = 200;
   useRedirectToLoginIfLoggedOut(personListRetrieveResults, API_RETRIEVE_ERRORS_IN_A_ROW_THRESHOLD); //or maybe taskDefinitionListRetrieveResults or taskGroupListRetrieveResults or taskStatusListRetrieveResults?
 
   useEffect(() => {

--- a/src/js/pages/Tasks.jsx
+++ b/src/js/pages/Tasks.jsx
@@ -76,7 +76,7 @@ const Tasks = () => {
     }
   }, [teamListRetrieveResults]);
 
-  const API_RETRIEVE_ERRORS_IN_A_ROW_THRESHOLD = 30;
+  const API_RETRIEVE_ERRORS_IN_A_ROW_THRESHOLD = 200;
   useRedirectToLoginIfLoggedOut(teamListRetrieveResults, API_RETRIEVE_ERRORS_IN_A_ROW_THRESHOLD);
 
   useEffect(() => {

--- a/src/js/pages/Teams.jsx
+++ b/src/js/pages/Teams.jsx
@@ -46,7 +46,7 @@ const Teams = () => {
   }, [personListRetrieveResults, allPeopleCache, dispatch]);
 
   const teamListRetrieveResults = useFetchData(['team-list-retrieve'], {}, METHOD.GET);
-  const API_RETRIEVE_ERRORS_IN_A_ROW_THRESHOLD = 50;
+  const API_RETRIEVE_ERRORS_IN_A_ROW_THRESHOLD = 200;
   useRedirectToLoginIfLoggedOut(teamListRetrieveResults, API_RETRIEVE_ERRORS_IN_A_ROW_THRESHOLD);
 
 

--- a/src/js/utils/useRedirectToLoginIfLoggedOut.js
+++ b/src/js/utils/useRedirectToLoginIfLoggedOut.js
@@ -6,10 +6,9 @@ import { useConnectAppContext } from '../contexts/ConnectAppContext';
 // a logged-out session by counting consecutive failures on endpoints that
 // require an active login. The threshold is intentionally high (50) because
 // occasional errors happen even when logged in; 15 was too trigger-happy.
-// const API_RETRIEVE_ERRORS_IN_A_ROW_THRESHOLD = 50;
-// Teams = 50, other pages make fewer requests and are set to 30, shouldn't be less than about 20.
-// Number might have to change in the future if/when the back-end requests etc are changed.
-// Now it's an argument rather than a constant.
+// API_RETRIEVE_ERRORS_IN_A_ROW_THRESHOLD was originall 30-50, and that worked for desktop tests,
+// but was too trigger-happy on mobile, detecting subsequent errors of a logged in user as proof of being logged out
+// now it's 200 to be on the safe side
 
 const useRedirectToLoginIfLoggedOut = (retrieveResults, retrieveErrorsThreshold) => {
   const API_RETRIEVE_ERRORS_IN_A_ROW_THRESHOLD = retrieveErrorsThreshold;
@@ -34,7 +33,7 @@ const useRedirectToLoginIfLoggedOut = (retrieveResults, retrieveErrorsThreshold)
       }
     } else if (retrieveResults.isSuccess === true && getAppContextValue('apiRetrieveErrorsInARowCount') !== 0) {
       setAppContextValue('apiRetrieveErrorsInARowCount', 0);
-      // console.log(`apiRetrieveErrorsInARowCount: ${getAppContextValue('apiRetrieveErrorsInARowCount')}`);
+      console.log(`apiRetrieveErrorsInARowCount: ${getAppContextValue('apiRetrieveErrorsInARowCount')}`);
     }
   }, [retrieveResults]); // eslint-disable-line react-hooks/exhaustive-deps
 };


### PR DESCRIPTION
## Summary
- Bump `API_RETRIEVE_ERRORS_IN_A_ROW_THRESHOLD` to 200 across `Tasks.jsx`, `Teams.jsx`, and `SystemSettings/SystemSettings.jsx`, and update the comment in `useRedirectToLoginIfLoggedOut.js`.

## Context
The WV-2636 implementation (#166) detects expired sessions on the front end by counting consecutive errors on authenticated API endpoints — there's no dedicated `/getAuthenticationStatus` endpoint to query. The original threshold of 30–50 worked in desktop testing, but Dale pointed out it was too trigger-happy on mobile, redirecting users to `/login` when their session was actually still valid (only desktop testing had been performed before). Raising the threshold to 200 across all pages makes false positives much less likely on mobile.

## Test plan
- [ ] Mobile: normal use (Tasks, Teams, SystemSettings) no longer triggers spurious redirects to `/login`
- [ ] Mobile + desktop: an actually expired session still eventually triggers the redirect (just takes longer to reach 200 errors)
- [ ] Confirm all three pages (Tasks, Teams, SystemSettings) use the new threshold value