### PR TITLE
[WV-4288] Edit individual task

### DIFF
--- a/src/js/components/Task/TaskListForPerson.jsx
+++ b/src/js/components/Task/TaskListForPerson.jsx
@@ -25,7 +25,6 @@ const TaskListForPerson = ({ searchText, selectedTaskType, showCompletedTasks, t
         // console.log('*** showTaskTemp:', showTaskTemp);
         return showTaskTemp ? (
           <div
-            key={`task-wrapper-${task.personId}-${task.taskDefinitionId}`}
             style={{
               display: 'flex',
               justifyContent: 'space-between',
@@ -34,6 +33,7 @@ const TaskListForPerson = ({ searchText, selectedTaskType, showCompletedTasks, t
           >
             <TaskSummaryRow
               hideIfCompleted={!showCompletedTasks}
+              key={`taskSummaryRow-${task.personId}-${task.taskDefinitionId}`}
               personId={convertToInteger(task.personId)}
               taskDefinition={taskDefinition}
               task={task}

--- a/src/js/components/Task/TaskListForPerson.jsx
+++ b/src/js/components/Task/TaskListForPerson.jsx
@@ -1,5 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import { IconButton } from '@mui/material';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
 import styled from 'styled-components';
 import { renderLog } from '../../common/utils/logging';
 import TaskSummaryRow from './TaskSummaryRow';
@@ -8,7 +10,7 @@ import convertToInteger from '../../common/utils/convertToInteger';
 import { TASK_TYPES } from '../../constants/TaskTypeConstants';
 
 
-const TaskListForPerson = ({ searchText, selectedTaskType, showCompletedTasks, taskDefinitionList, taskListForPersonId }) => {
+const TaskListForPerson = ({ searchText, selectedTaskType, showCompletedTasks, taskDefinitionList, taskListForPersonId, onTaskMenuOpen, tasksPage }) => {
   renderLog('TaskListForPerson');  // Set LOG_RENDER_EVENTS to log all renders
   // console.log('=== TaskListForPerson searchText:', searchText);
   // isSearchTextFoundInTask(searchText, task, taskDefinitionList)
@@ -22,13 +24,29 @@ const TaskListForPerson = ({ searchText, selectedTaskType, showCompletedTasks, t
         const showTaskTemp = taskTypeMatches && showTask(task, searchText, taskDefinitionList);
         // console.log('*** showTaskTemp:', showTaskTemp);
         return showTaskTemp ? (
-          <TaskSummaryRow
-            hideIfCompleted={!showCompletedTasks}
-            key={`taskSummaryRow-${task.personId}-${task.taskDefinitionId}`}
-            personId={convertToInteger(task.personId)}
-            taskDefinition={taskDefinition}
-            task={task}
-          />
+          <div
+            key={`task-wrapper-${task.personId}-${task.taskDefinitionId}`}
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+            }}
+          >
+            <TaskSummaryRow
+              hideIfCompleted={!showCompletedTasks}
+              personId={convertToInteger(task.personId)}
+              taskDefinition={taskDefinition}
+              task={task}
+            />
+            {/* Conditional triple dot */}
+            {tasksPage && (showCompletedTasks || !task.statusDone) && (
+              <IconButton
+                onClick={(e) => onTaskMenuOpen(e, task, taskDefinition)}
+              >
+                <MoreVertIcon />
+              </IconButton>
+            )}
+          </div>
         ) : null;
       })}
     </TaskListWrapper>
@@ -40,6 +58,8 @@ TaskListForPerson.propTypes = {
   showCompletedTasks: PropTypes.bool,
   taskDefinitionList: PropTypes.array,
   taskListForPersonId: PropTypes.array,
+  onTaskMenuOpen: PropTypes.func,
+  tasksPage: PropTypes.bool,
 };
 
 const TaskListWrapper = styled('div')`

--- a/src/js/models/TaskModel.jsx
+++ b/src/js/models/TaskModel.jsx
@@ -239,6 +239,34 @@ export function captureTaskStatusListRetrieveData (
       }
     });
   }
+
+  let taskDeletionDetected = false;
+  const incomingTaskKeys = new Set();
+
+  if (data && data.taskList && isSuccess === true) {
+    data.taskList.forEach((task) => {
+      if (task && task.personId >= 0 && task.taskDefinitionId >= 0) {
+        incomingTaskKeys.add(`${task.personId}-${task.taskDefinitionId}`);
+      }
+    });
+
+    // DELETE DETECTION
+    Object.entries(allTasksCacheNew).forEach(([personId, taskMap]) => {
+      Object.keys(taskMap).forEach((taskDefinitionId) => {
+        const key = `${personId}-${taskDefinitionId}`;
+
+        if (!incomingTaskKeys.has(key)) {
+          delete allTasksCacheNew[personId][taskDefinitionId];
+          taskDeletionDetected = true;
+        }
+      });
+
+      // cleanup empty objects
+      if (Object.keys(allTasksCacheNew[personId]).length === 0) {
+        delete allTasksCacheNew[personId];
+      }
+    });
+  }
   // if (newTaskDefinitionListDataReceived) {
   //   // console.log('TaskStatusListRetrieve setting allTaskDefinitionsCacheNew:', allTaskDefinitionsCacheNew);
   //   dispatch({ type: 'updateByKeyValue', key: 'allTaskDefinitionsCache', value: allTaskDefinitionsCacheNew });
@@ -257,7 +285,7 @@ export function captureTaskStatusListRetrieveData (
     changeResults.allTasksByDefinitionIdCache = allTasksByDefinitionIdCacheNew;
     changeResults.allTasksByDefinitionIdCacheChanged = true;
   }
-  if (newTaskListDataReceived) {
+  if (newTaskListDataReceived || taskDeletionDetected) {
     // console.log('TaskStatusListRetrieve setting allTasksCacheNew:', allTasksCacheNew);
     dispatch({ type: 'updateByKeyValue', key: 'allTasksCache', value: allTasksCacheNew });
     changeResults.allTasksCache = allTasksCacheNew;

--- a/src/js/pages/Tasks.jsx
+++ b/src/js/pages/Tasks.jsx
@@ -1,4 +1,17 @@
 import { withStyles } from '@mui/styles';
+import {
+  Menu,
+  MenuItem,
+  Drawer,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Checkbox,
+  FormControlLabel,
+  Typography,
+} from '@mui/material';
 import React, { useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import styled from 'styled-components';
@@ -20,6 +33,9 @@ import { alphabetizePeoplesObject } from '../utils/utilities';
 import { showTaskDefinition } from '../utils/showTask';
 import TaskSummaryRow from '../components/Task/TaskSummaryRow';
 import convertToInteger from '../common/utils/convertToInteger';
+import { useGetFullNamePreferred } from '../models/PersonModel';
+import { useSaveTaskMutation, useDeleteTaskMutation } from '../react-query/mutations';
+import { makeRequestParamsDictionary } from '../react-query/makeRequestParams';
 import { TASK_TYPE_LIST, TASK_TYPES } from '../constants/TaskTypeConstants';
 import useRedirectToLoginIfLoggedOut from '../utils/useRedirectToLoginIfLoggedOut';
 
@@ -39,6 +55,21 @@ const Tasks = () => {
   const [showTasksByTask, setShowTasksByTask] = useState(false);
   const [taskListByPersonId, setTaskListByPersonId] = useState({});
   const [taskDefinitionList, setTaskDefinitionList] = useState([]);
+
+  const [menuAnchorEl, setMenuAnchorEl] = (useState(null));
+  const [selectedTask, setSelectedTask] = useState(null);
+
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+
+  const doneByPersonFullName = useGetFullNamePreferred(selectedTask?.doneByPersonId);
+
+  const { mutate: saveTask } = useSaveTaskMutation();
+  const { mutate: deleteTask } = useDeleteTaskMutation();
+
+  const authenticatedPerson = getAppContextValue('authenticatedPerson');
+  const authenticatedPersonId = authenticatedPerson?.id || -1;
+
 
   const personListRetrieveResults = useFetchData(['person-list-retrieve'], {}, METHOD.GET);
 
@@ -124,6 +155,64 @@ const Tasks = () => {
       setHideAllTasks(!hideAllTasks);
     }
   }, [getAppContextValue]);
+
+  const handleMenuOpen = (event, task, taskDefinition) => {
+    setMenuAnchorEl(event.currentTarget);
+    setSelectedTask({ ...task, taskDefinition });
+  };
+
+  const handleMenuClose = () => {
+    setMenuAnchorEl(null);
+  };
+
+  const handleEditClick = () => {
+    handleMenuClose();
+    setIsDrawerOpen(true);
+  };
+
+  const handleDeleteClick = () => {
+    handleMenuClose();
+    setIsDeleteDialogOpen(true);
+  };
+
+  const handleDrawerClose = () => {
+    setIsDrawerOpen(false);
+  };
+
+  const handleDeleteConfirm = () => {
+    const deleteRequestParams = makeRequestParamsDictionary(
+      {
+        personId: selectedTask.personId,
+        taskDefinitionId: selectedTask.taskDefinitionId,
+      },
+      {},
+    );
+    deleteTask(deleteRequestParams);
+    setIsDeleteDialogOpen(false);
+  };
+
+  const handleStatusChange = (e) => {
+    const isDone = e.target.checked;
+
+    // Update local UI immediately
+    setSelectedTask((prev) => ({
+      ...prev,
+      statusDone: isDone,
+      doneByPersonId: authenticatedPersonId,
+    }));
+    const requestParams = makeRequestParamsDictionary(
+      {
+        personId: selectedTask.personId,
+        taskDefinitionId: selectedTask.taskDefinitionId,
+      },
+      {
+        doneByPersonId: authenticatedPersonId,
+        statusDone: isDone,
+      },
+    );
+    saveTask(requestParams);
+  };
+
 
   const teamId = 0;  // hack 1/15/25
   // console.log('allTasksByDefinitionIdCache:', allTasksByDefinitionIdCache);
@@ -231,6 +320,8 @@ const Tasks = () => {
                           showCompletedTasks={showCompletedTasks}
                           taskDefinitionList={taskDefinitionList}
                           taskListForPersonId={taskListByPersonId[person.personId] || []}
+                          onTaskMenuOpen={handleMenuOpen}
+                          tasksPage
                         />
                       )}
                     </OnePersonWrapper>
@@ -243,6 +334,77 @@ const Tasks = () => {
           )}
         </div>
       </PageContentContainer>
+      <Menu
+        anchorEl={menuAnchorEl}
+        open={Boolean(menuAnchorEl)}
+        onClose={handleMenuClose}
+      >
+        <MenuItem onClick={handleEditClick}>Edit</MenuItem>
+        <MenuItem onClick={handleDeleteClick}>Delete</MenuItem>
+      </Menu>
+      <Drawer anchor="right" open={isDrawerOpen} onClose={handleDrawerClose}>
+        <div
+          style={{
+            width: 350,
+            padding: 20,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 16,
+          }}
+        >
+          <Typography variant="h6">Edit Task</Typography>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <Typography>
+              Task: {selectedTask?.taskDefinition?.taskName}
+            </Typography>
+
+            {selectedTask?.statusDone && (
+              <Typography>
+                Completed By: {doneByPersonFullName}
+              </Typography>
+            )}
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+            <FormControlLabel
+              control={(
+                <Checkbox
+                  checked={selectedTask?.statusDone || false}
+                  onChange={handleStatusChange}
+                />
+              )}
+              label="Status Done"
+            />
+
+            <Button
+              variant="contained"
+              color="error"
+              onClick={() => {
+                setIsDrawerOpen(false);
+                setIsDeleteDialogOpen(true);
+              }}
+            >
+              Delete
+            </Button>
+          </div>
+        </div>
+      </Drawer>
+      <Dialog
+        open={isDeleteDialogOpen}
+        onClose={() => setIsDeleteDialogOpen(false)}
+      >
+        <DialogTitle>Confirm Delete</DialogTitle>
+        <DialogContent>
+          Are you sure you want to delete this task?
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setIsDeleteDialogOpen(false)}>Cancel</Button>
+          <Button color="error" onClick={handleDeleteConfirm}>
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
     </div>
   );
 };

--- a/src/js/react-query/mutations.jsx
+++ b/src/js/react-query/mutations.jsx
@@ -108,6 +108,14 @@ const useTaskGroupTeamLinkDeleteMutation = () => {
   });
 };
 
+const useDeleteTaskMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation({ mutationFn: (params) => weConnectQueryFn('task-delete', params, METHOD.GET),
+    onError: (error) => console.log('error in useDeleteTaskMutation: ', error),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['task-status-list-retrieve']}),
+  });
+};
+
 const useTaskGroupTeamLinkSaveMutation = () => {
   const queryClient = useQueryClient();
   return useMutation({ mutationFn: (params) => weConnectQueryFn('task-group-team-link-save', params, METHOD.GET),
@@ -263,5 +271,6 @@ export {
   useTaskGroupSaveMutation,
   useTaskGroupTeamLinkDeleteMutation, useTaskGroupTeamLinkSaveMutation,
   useProfileChangeLogRetrieveMutation,
+  useDeleteTaskMutation,
 };
 


### PR DESCRIPTION
### What github.com/wevote/weconnect/issues does this fix?

WV-4288: Edit individual task

### Changes included this pull request?

* Added triple-dot action menu for each task row with:
    * Edit
    * Delete
* Added Edit Task drawer displaying:
    * Task name
    * Completed by information (for completed tasks)
    * Status Done checkbox
    * Delete button
* Added delete confirmation modal before removing tasks.
* Implemented task delete mutation with query invalidation to refresh task data.
* Added task deletion handling in TaskModel cache logic to properly remove deleted tasks from local cache/state.
* Added conditional rendering for action menu visibility:
    * Visible only on Tasks page
    * Hidden for completed tasks when completed tasks are filtered out
