### PR TITLE
[WV-4545] Fix Show > Resigned filter on Teams page

### DIFF
--- a/src/js/utils/showPerson.js
+++ b/src/js/utils/showPerson.js
@@ -36,17 +36,17 @@ export const showPersonInMemberList = (person, searchTextLocal, getAppContextVal
   } else if (pigsCanFly) {
     // Used for testing while developing
     return true;
+  } else if (getAppContextValue('peopleFilterExactMatchVsLogicalOr') === 'EXACT_MATCH') {
+    // "Only" option, where we only show people who match the exact filters
+    return onlyShowPersonWithPeopleFiltersExactMatch(person, getAppContextValue);
+  } else if (getAppContextValue('peopleFilterExactMatchVsLogicalOr') === 'LOGICAL_OR') {
+    // "Include" option, where we show people who match any of the filters
+    return onlyShowPersonWithPeopleFiltersLogicalOrMatch(person, getAppContextValue);
   } else if (person.statusActive === false) {   // Mar 2026, Allow people with null statusActive through
     // Only show people marked with statusActive = false when searching
     // Mar 2026: Hopefully we won't find null statusActive going forward, but treat these as true
     // Eventually weave in the ability to show as a "show" filter option
     return false;
-  } else if (getAppContextValue('peopleFilterExactMatchVsLogicalOr') === 'LOGICAL_OR') {
-    // "Include" option, where we show people who match any of the filters
-    return onlyShowPersonWithPeopleFiltersLogicalOrMatch(person, getAppContextValue);
-  } else if (getAppContextValue('peopleFilterExactMatchVsLogicalOr') === 'EXACT_MATCH') {
-    // "Only" option, where we only show people who match the exact filters
-    return onlyShowPersonWithPeopleFiltersExactMatch(person, getAppContextValue);
   } else {
     return true; // Show the person if no searchText is provided, or there are any other filters
   }


### PR DESCRIPTION
Reorder branches in showPersonInMemberList so the EXACT_MATCH and LOGICAL_OR filter checks run before the 
`statusActive === false` early-return. 

The guard was rejecting resigned people before their explicit Show filter could be consulted, so "Only > Resigned" and "Include > Resigned" both returned empty rows even when resigned team members existed.