### PR TITLE
[WV-4556] WeConnect: Add the ability to delete a profile [TEAM REVIEW]

### DIFF
--- a/src/js/components/Person/EditPersonForm.jsx
+++ b/src/js/components/Person/EditPersonForm.jsx
@@ -15,7 +15,7 @@ import webAppConfig from '../../config';
 import { useConnectAppContext } from '../../contexts/ConnectAppContext';
 import { viewerCanSeeOrDo } from '../../models/AuthModel';
 import { makeRequestParamsDictionary } from '../../react-query/makeRequestParams';
-import { usePersonSaveMutation } from '../../react-query/mutations';
+import { usePersonSaveMutation, usePersonDeleteMutation } from '../../react-query/mutations';
 import weConnectQueryFn, { METHOD } from '../../react-query/WeConnectQuery';
 import { SpanWithLinkStyle } from '../Style/linkStyles';
 import EmailOfficialManager from './EmailOfficialManager';
@@ -31,6 +31,7 @@ const EditPersonForm = ({ classes }) => {
   const { apiDataCache, getAppContextValue, setAppContextValue } = useConnectAppContext();
   const { viewerAccessRights } = apiDataCache;
   const { mutate: personSave } = usePersonSaveMutation(); // Alternate: usePersonSave();
+  const { mutate: personDelete } = usePersonDeleteMutation();
 
   const [allOnboardingCheckboxesChecked, setAllOnboardingCheckboxesChecked] = useState(false);
   const [emailOfficialEdited, setEmailOfficialEdited] = useState(false);
@@ -52,6 +53,7 @@ const EditPersonForm = ({ classes }) => {
   const [slackError, setSlackError] = useState('');
   const [dateStartError, setDateStartError] = useState('');
   const [dateEndError, setDateEndError] = useState('');
+  const [deleteConfirmed, setDeleteConfirmed] = useState(false);
 
   const getDateDefaultValue = (dateString) => {
     if (!dateString) return null;
@@ -209,6 +211,15 @@ const EditPersonForm = ({ classes }) => {
       setAppContextValue('profileDrawerPerson', undefined);
       setAppContextValue('profileDrawerPersonId', -1);
     }
+  };
+
+  const deletePersonProfile = () => {
+    const plainParams = {
+      personId: activePerson.id,
+    };
+    console.log('Deleting person with ID:', activePerson.id);
+    personDelete(plainParams);
+    setDeleteConfirmed(false);
   };
 
   const setEmailOfficialFromChild = (emailOfficial) => {
@@ -906,6 +917,33 @@ const EditPersonForm = ({ classes }) => {
           )}
           label={`${activePerson.firstNamePreferred || activePerson.firstName} is a monthly donor`}
         />
+        <DeleteConfirmationWrapper style={viewerIsOnHrTeam ? {} : { display: 'none' }}>
+          <Button
+            classes={{ root: classes.deletePersonButton }}
+            color="primary"
+            disabled={!deleteConfirmed || !!dateStartError || !!dateEndError}
+            onClick={() => deletePersonProfile()}
+            variant="contained"
+          >
+            Delete Person
+          </Button>
+          <CheckboxLabel
+            classes={{ label: classes.checkboxLabel }}
+            control={(
+              <Checkbox
+                checked={deleteConfirmed || false}
+                className={classes.checkboxRoot}
+                color="primary"
+                id="deleteConfirmationCheckbox"
+                name="deleteConfirmation"
+                onChange={(event) => {
+                  setDeleteConfirmed(event.target.checked);
+                }}
+              />
+            )}
+            label="Confirm you want to permanently delete this profile"
+          />
+        </DeleteConfirmationWrapper>
         <ButtonWrapper>
           <Button
             classes={{ root: classes.savePersonButton }}
@@ -955,6 +993,16 @@ const styles = (theme) => ({
       color: '#424242 !important',
     },
   },
+  deletePersonButton: {
+    width: '150px',
+    [theme.breakpoints.down('md')]: {
+      width: '100%',
+    },
+    '&.Mui-disabled': {
+      backgroundColor: '#e0e0e0 !important',
+      color: '#424242 !important',
+    },
+  },
 });
 
 const ButtonWrapper = styled('div')`
@@ -979,6 +1027,13 @@ const DateOptionsWrapper = styled('div')`
 
 const DateWrapper = styled('div')`
   margin-right: 4px;
+`;
+
+const DeleteConfirmationWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
 `;
 
 const EditPersonFormWrapper = styled('div')`

--- a/src/js/react-query/mutations.jsx
+++ b/src/js/react-query/mutations.jsx
@@ -142,7 +142,6 @@ const usePersonAwaySaveMutation = () => {
   });
 };
 
-// Copied to /models/PersonModel.jsx with a non-conflicting function name
 const usePersonSaveMutation = () => {
   const queryClient = useQueryClient();
   const { apiDataCache } = useConnectAppContext();
@@ -173,6 +172,30 @@ const usePersonSaveMutation = () => {
           .catch((error) => console.error('userPersonSaveMutation person-list-retrieve refetch failed:', error));
       } else {
         console.log('usePersonSaveMutation personId not >= 0:', results);
+      }
+    },
+  });
+};
+
+const usePersonDeleteMutation = () => {
+  const queryClient = useQueryClient();
+  const { setAppContextValue } = useConnectAppContext();
+
+  return useMutation({
+    mutationFn: (params) => weConnectQueryFn('person-delete', params, METHOD.GET),
+    onError: (error) => console.log('error in usePersonDeleteMutation: ', error),
+    onSuccess: (results) => {
+      console.log('usePersonDeleteMutation onSuccess, results:', results);
+      if (results.success === true) {
+        // Invalidate person list to refresh the list after deletion
+        queryClient.invalidateQueries({ queryKey: ['person-list-retrieve']});
+        queryClient.invalidateQueries({ queryKey: ['team-list-retrieve']});
+        // Close the profile drawer
+        setAppContextValue('headerProfileDrawerOpen', false);
+        setAppContextValue('profileDrawerPerson', undefined);
+        setAppContextValue('profileDrawerPersonId', -1);
+      } else {
+        console.log('usePersonDeleteMutation onSuccess but success flag is false:', results);
       }
     },
   });
@@ -253,7 +276,7 @@ const usePersonRetrieveByEmailMutation = () => {
 export {
   useAddPersonToTeamMutation, useAnswerListSaveMutation, useGetAuthMutation,
   useLogoutMutation, useMeetingSaveMutation, usePasswordSaveMutation,
-  usePersonAwaySaveMutation, usePersonSaveMutation,
+  usePersonAwaySaveMutation, usePersonDeleteMutation, usePersonSaveMutation,
   usePersonRetrieveMutation, usePersonRetrieveByEmailMutation,
   useQuestionListSaveMutation, useQuestionnaireSaveMutation,
   useQuestionSaveMutation,


### PR DESCRIPTION
### What github.com/wevote/weconnect/issues does this fix?
[WV-4556] WeConnect: Add the ability to delete a profile
### Changes included this pull request?

_src/js/components/Person/EditPersonForm.jsx_
Added UI updates to include the required button and checkbox as specified in the ticket requirements.
_src/js/react-query/mutations.jsx_
Added a React Query mutation to invoke the server API for deleting a person profile using the person ID.

[WV-4556]: https://wevoteusa.atlassian.net/browse/WV-4556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ