### PR TITLE
[WV-4556] WeConnect: Add the ability to delete a profile--Support person disappears from the interface  [TEAM REVIEW]

### DIFF
--- a/src/js/react-query/mutations.jsx
+++ b/src/js/react-query/mutations.jsx
@@ -187,17 +187,31 @@ const usePersonSaveMutation = () => {
 
 const usePersonDeleteMutation = () => {
   const queryClient = useQueryClient();
-  const { setAppContextValue } = useConnectAppContext();
+  const { setAppContextValue, apiDataCache } = useConnectAppContext();
+  const dispatch = useConnectDispatch();
 
   return useMutation({
     mutationFn: (params) => weConnectQueryFn('person-delete', params, METHOD.GET),
     onError: (error) => console.log('error in usePersonDeleteMutation: ', error),
-    onSuccess: (results) => {
-      // console.log('usePersonDeleteMutation onSuccess, results:', results);
+    onSuccess: (results, variables) => {
+      const { allPeopleCache } = apiDataCache;
+      const deletedId = results?.personId || variables?.personId || variables?.id;
+
+      // console.log('usePersonDeleteMutation onSuccess, deletedId:', deletedId, ', results:', results);
       if (results.success === true) {
-        // Invalidate person list to refresh the list after deletion
-        queryClient.invalidateQueries({ queryKey: ['person-list-retrieve']});
-        queryClient.invalidateQueries({ queryKey: ['team-list-retrieve']});
+
+        // Remove the deleted person from allPeopleCache
+        const allPeopleCacheNew = { ...allPeopleCache };
+        delete allPeopleCacheNew[deletedId];
+        dispatch({ type: 'updateByKeyValue', key: 'allPeopleCache', value: allPeopleCacheNew });
+
+        // Completely erase the list memory BEFORE triggering a refetch to stop stale data syncs
+        queryClient.removeQueries({ queryKey: ['person-list-retrieve']});
+        queryClient.removeQueries({ queryKey: ['team-list-retrieve']});
+
+        // Trigger a fresh background fetch for safety
+        queryClient.refetchQueries({ queryKey: ['person-list-retrieve']}).catch((error) =>  console.error('userPersonDeletMutation person-list-retrieve refetch failed:', error));
+        queryClient.refetchQueries({ queryKey: ['team-list-retrieve']}).catch((error) =>  console.error('userPersonDeletMutation team-list-retrieve refetch failed:', error));
         // Close the profile drawer
         setAppContextValue('headerProfileDrawerOpen', false);
         setAppContextValue('profileDrawerPerson', undefined);
@@ -296,4 +310,3 @@ export {
   useProfileChangeLogRetrieveMutation,
   useDeleteTaskMutation,
 };
-

--- a/src/js/react-query/mutations.jsx
+++ b/src/js/react-query/mutations.jsx
@@ -199,7 +199,6 @@ const usePersonDeleteMutation = () => {
 
       // console.log('usePersonDeleteMutation onSuccess, deletedId:', deletedId, ', results:', results);
       if (results.success === true) {
-
         // Remove the deleted person from allPeopleCache
         const allPeopleCacheNew = { ...allPeopleCache };
         delete allPeopleCacheNew[deletedId];


### PR DESCRIPTION
### What github.com/wevote/weconnect/issues does this fix?
[WV-4556]WeConnect: Add the ability to delete a profile
### Changes included this pull request?
_src/js/react-query/mutations.jsx_

- Updated the UI so that a person is removed from the interface immediately after a successful response is received from weconnect-server.
- Replaced` queryClient.invalidateQueries()` for **person-list-retrieve** and **team-list-retrieve** with a combination of:
```
     queryClient.removeQueries()
     queryClient.refetchQueries()
```
- This change addresses an issue caused by maintaining both a local context cache (`apiDataCache.allPeopleCache`) and the React Query cache. Simply invalidating queries could temporarily display outdated data ("stale data flashing") before fresh data was loaded.
- Removing the cached queries before refetching ensures stale data is not rendered and keeps the UI in sync with the latest server state.

[WV-4556]: https://wevoteusa.atlassian.net/browse/WV-4556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ