### PR TITLE
WV-4619

### DIFF
--- a/src/js/pages/SystemSettings/SystemSettings.jsx
+++ b/src/js/pages/SystemSettings/SystemSettings.jsx
@@ -25,7 +25,7 @@ const SystemSettings = () => {
   const [personIdsList, setPersonIdsList] = useState([]);
 
   const personListRetrieveResults = useFetchData(['person-list-retrieve'], {}, METHOD.GET);
-  const API_RETRIEVE_ERRORS_IN_A_ROW_THRESHOLD = 200;
+  const API_RETRIEVE_ERRORS_IN_A_ROW_THRESHOLD = 50; // WV-4619: lowered from 200 now that only genuine 403 auth errors are counted
   useRedirectToLoginIfLoggedOut(personListRetrieveResults, API_RETRIEVE_ERRORS_IN_A_ROW_THRESHOLD); //or maybe taskDefinitionListRetrieveResults or taskGroupListRetrieveResults or taskStatusListRetrieveResults?
 
   useEffect(() => {

--- a/src/js/pages/Tasks.jsx
+++ b/src/js/pages/Tasks.jsx
@@ -106,7 +106,7 @@ const Tasks = () => {
     }
   }, [teamListRetrieveResults]);
 
-  const API_RETRIEVE_ERRORS_IN_A_ROW_THRESHOLD = 200;
+  const API_RETRIEVE_ERRORS_IN_A_ROW_THRESHOLD = 50; // WV-4619: lowered from 200 now that only genuine 403 auth errors are counted
   useRedirectToLoginIfLoggedOut(teamListRetrieveResults, API_RETRIEVE_ERRORS_IN_A_ROW_THRESHOLD);
 
   useEffect(() => {

--- a/src/js/pages/Teams.jsx
+++ b/src/js/pages/Teams.jsx
@@ -46,7 +46,7 @@ const Teams = () => {
   }, [personListRetrieveResults, allPeopleCache, dispatch]);
 
   const teamListRetrieveResults = useFetchData(['team-list-retrieve'], {}, METHOD.GET);
-  const API_RETRIEVE_ERRORS_IN_A_ROW_THRESHOLD = 200;
+  const API_RETRIEVE_ERRORS_IN_A_ROW_THRESHOLD = 50; // WV-4619: lowered from 200 now that only genuine 403 auth errors are counted
   useRedirectToLoginIfLoggedOut(teamListRetrieveResults, API_RETRIEVE_ERRORS_IN_A_ROW_THRESHOLD);
 
 

--- a/src/js/react-query/WeConnectQuery.js
+++ b/src/js/react-query/WeConnectQuery.js
@@ -66,10 +66,24 @@ const weConnectQueryFn = async (queryKey, params, isGet, forceMaster = false) =>
     }
   } catch (err) {
     const errorMsg = typeof err !== 'undefined' ? err : '';
-    if (!errorMsg?.message.includes('403')) {
+    const httpStatusCode = err?.response?.status;
+    // A 403 from an authenticated endpoint means "not authorized" (likely logged out), as opposed
+    // to a transient network error (timeout, 5xx, dropped request). Telling them apart lets the
+    // logged-out-redirect heuristic count only genuine auth failures. (WV-4619)
+    const isAuthError = httpStatusCode === 403 || (errorMsg?.message?.includes('403') ?? false);
+    if (!isAuthError) {
       window.networkError = true;
     }
     console.error('Axios ', (isGet ? 'axios.get' : 'axios.post'), ' error: ', errorMsg);
+    // Re-throw so React Query records the failed query and exposes the error (with its HTTP status)
+    // to callers via useFetchData. Tag it so callers can distinguish an auth failure from a network
+    // error without re-parsing the message. (Previously errors were swallowed and undefined was
+    // returned, which React Query already treated as a failed query, so callers see no change.)
+    if (err && typeof err === 'object') {
+      err.weConnectIsAuthError = isAuthError;
+      err.weConnectHttpStatusCode = httpStatusCode;
+    }
+    throw err;
   }
 
   return response?.data;
@@ -90,11 +104,14 @@ const useFetchData = (queryKey, fetchParams, isGet, shouldExecute = true, queryO
   if (error) {
     console.log(`An error occurred with ${queryKey}, queryOptions ${queryOptions}: ${error.message}`);
   }
+  // WV-4619: surface whether the most recent failure was an auth error (403 / likely logged out)
+  // vs. a transient network error, so useRedirectToLoginIfLoggedOut counts only genuine auth failures.
+  const isAuthError = error ? (error.weConnectIsAuthError === true || error?.response?.status === 403) : false;
   // if (queryKey === 'task-status-list-retrieve')   {
   //   console.log(`-----${queryKey} isSuccess: ${isSuccess}, isStale: ${isStale}, refetch: ${refetch}`);
   //   console.log(`+++++${queryKey} data: ${JSON.stringify(data)}`);
   // }
-  return { data, isSuccess, isFetching, isStale, refetch };
+  return { data, isSuccess, isFetching, isStale, refetch, isAuthError };
 };
 
 export default weConnectQueryFn;

--- a/src/js/utils/useRedirectToLoginIfLoggedOut.js
+++ b/src/js/utils/useRedirectToLoginIfLoggedOut.js
@@ -3,15 +3,33 @@ import { useNavigate } from 'react-router';
 import { useConnectAppContext } from '../contexts/ConnectAppContext';
 
 // Because we don't yet have an API endpoint to check session status, we infer
-// a logged-out session by counting consecutive failures on endpoints that
-// require an active login. The threshold is intentionally high (50) because
-// occasional errors happen even when logged in; 15 was too trigger-happy.
-// API_RETRIEVE_ERRORS_IN_A_ROW_THRESHOLD was originally 30-50, and that worked for desktop tests,
-// but was too trigger-happy on mobile, detecting subsequent errors of a logged in user as proof of being logged out
-// now it's 200 to be on the safe side
+// a logged-out session by counting consecutive AUTH failures (HTTP 403) on endpoints that
+// require an active login.
+// WV-4619: Three guards make this far less trigger-happy than the original "count every failed
+// request" approach (which misfired on mobile). ALL must be satisfied before we redirect:
+//   1. Count only genuine auth failures (403). Transient network errors (timeouts, 5xx, dropped
+//      requests) and in-flight/pending states are ignored -- those do NOT mean you're logged out,
+//      and on flaky mobile connections they were the main cause of false logouts. (isAuthError is
+//      surfaced by useFetchData / weConnectQueryFn.) The count threshold is passed in by the page.
+//   2. Page-load grace period (THE ticket requirement): the redirect check is suppressed entirely
+//      for the first 60 seconds after the page loads. No matter how many 403s pile up in that
+//      window, we never redirect. Measured with performance.now() (ms since document load).
+//   3. Error-streak duration (extra false-positive protection, BEYOND the original ask -- flag in
+//      PR/to Dale): the uninterrupted 403 streak must also last >= 60 seconds. Any successful
+//      request resets it, so a short burst of 403s won't redirect. Empirically this prevents the
+//      false logouts without ever firing on transient trouble. Guards 2 and 3 are deliberately
+//      separate gates with different meanings; keeping both is intentional, not redundant.
+// Because we now count only real 403s, the count threshold can be much lower than the old 200.
+
+// Guard 2: how long after page load before the redirect check is allowed to run at all.
+const REDIRECT_TO_LOGIN_GRACE_AFTER_PAGE_LOAD_MS = 60 * 1000;
+// Guard 3: minimum duration an uninterrupted 403 streak must last (reset by any success).
+const REDIRECT_TO_LOGIN_MINIMUM_ERROR_STREAK_MS = 60 * 1000;
 
 const useRedirectToLoginIfLoggedOut = (retrieveResults, retrieveErrorsThreshold) => {
-  const REDIRECT_TO_LOGIN_TURNED_OFF = true; // This feature is currently causing some problems for the HR team, so we're disabling it for now.
+  // Dale's master switch: keeps this whole feature (the redirect AND the WV-4619 60-second gate)
+  // disable-able for prod until he deems it ready. The two are tied together by this one flag.
+  const REDIRECT_TO_LOGIN_TURNED_OFF = false;
   const API_RETRIEVE_ERRORS_IN_A_ROW_THRESHOLD = retrieveErrorsThreshold;
   const { apiDataCache, getAppContextValue, setAppContextValue } = useConnectAppContext();
   const navigate = useNavigate();
@@ -19,23 +37,41 @@ const useRedirectToLoginIfLoggedOut = (retrieveResults, retrieveErrorsThreshold)
   useEffect(() => {
     if (REDIRECT_TO_LOGIN_TURNED_OFF) return;
     if (!retrieveResults) return;
-    if (retrieveResults.isSuccess === false) {
-      if (getAppContextValue('apiRetrieveErrorsInARowCount') === null) {
+    if (retrieveResults.isSuccess === true) {
+      // A successful authenticated request proves the session is valid: reset the streak.
+      if (getAppContextValue('apiRetrieveErrorsInARowCount') !== 0) {
         setAppContextValue('apiRetrieveErrorsInARowCount', 0);
+        setAppContextValue('apiRetrieveErrorsFirstErrorTimestampMs', null);
       }
-      setAppContextValue('apiRetrieveErrorsInARowCount', getAppContextValue('apiRetrieveErrorsInARowCount') + 1);
-      // console.log(`apiRetrieveErrorsInARowCount: ${getAppContextValue('apiRetrieveErrorsInARowCount')}`);
-      if (getAppContextValue('apiRetrieveErrorsInARowCount') >= API_RETRIEVE_ERRORS_IN_A_ROW_THRESHOLD &&
+    } else if (retrieveResults.isAuthError === true) {
+      // Only genuine auth failures (403) count toward "you're logged out". Network errors and
+      // pending states fall through and are ignored (they neither increment nor reset the streak).
+      const previousErrorsInARowCount = getAppContextValue('apiRetrieveErrorsInARowCount') || 0;
+      if (previousErrorsInARowCount === 0) {
+        // Start of a new auth-error streak: stamp the moment the first 403 occurred.
+        setAppContextValue('apiRetrieveErrorsFirstErrorTimestampMs', Date.now());
+      }
+      const errorsInARowCount = previousErrorsInARowCount + 1;
+      setAppContextValue('apiRetrieveErrorsInARowCount', errorsInARowCount);
+      // console.log(`apiRetrieveErrorsInARowCount: ${errorsInARowCount}`);
+
+      const firstErrorTimestampMs = getAppContextValue('apiRetrieveErrorsFirstErrorTimestampMs');
+      const errorStreakDurationMs = firstErrorTimestampMs ? Date.now() - firstErrorTimestampMs : 0;
+      // performance.now() = ms since this page (document) loaded. A hard reload resets it to 0;
+      // SPA navigation between Teams/Tasks/Settings does not.
+      const msSincePageLoad = performance.now();
+
+      if (errorsInARowCount >= API_RETRIEVE_ERRORS_IN_A_ROW_THRESHOLD &&
+        msSincePageLoad >= REDIRECT_TO_LOGIN_GRACE_AFTER_PAGE_LOAD_MS &&
+        errorStreakDurationMs >= REDIRECT_TO_LOGIN_MINIMUM_ERROR_STREAK_MS &&
         apiDataCache.viewerAccessRights !== null &&
         apiDataCache.viewerAccessRights.canAddPerson !== null
       ) {
         setAppContextValue('apiRetrieveErrorsInARowCount', 0);
+        setAppContextValue('apiRetrieveErrorsFirstErrorTimestampMs', null);
         navigate('/login');
         navigate(0);
       }
-    } else if (retrieveResults.isSuccess === true && getAppContextValue('apiRetrieveErrorsInARowCount') !== 0) {
-      setAppContextValue('apiRetrieveErrorsInARowCount', 0);
-      console.log(`apiRetrieveErrorsInARowCount: ${getAppContextValue('apiRetrieveErrorsInARowCount')}`);
     }
   }, [retrieveResults]); // eslint-disable-line react-hooks/exhaustive-deps
 };


### PR DESCRIPTION
Completed WV-4619 -- now only counts 403s towards errors-in-a-row logic before redirecting to login, waits 60 seconds before any possible login redirect after the initial page load, and for additional protection against false positive/trigger-happy redirects, there must be a 60 second streak of errors in order to trigger a redirect, regardless of the errors-in-a-row count. End result: user gets redirected about 2 minutes after session is invalid. Also lowered the threshold from 200 to 50. I tested this extensively, including with network throttling to "3G" or even "offline" in Chrome dev tools, so that any network issues wouldn't result in errors that count towards the errors-in-a-row count that result in a redirect. The limitation of this whole approach is that the front-end basically has to infer (guess/conclude) that the session is invalid, as it does not use some endpoint that checks authentication status. But by focusing on 403 Forbidden errors, this is about as good as it can get with the limitations I've been given for this task. This should result in far fewer false positive redirects compared to my previous approach, now that the error count scope is much more specific.